### PR TITLE
process: improve is_alive by checking starttime and state

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -855,9 +855,14 @@ impl Process {
     pub fn is_alive(&self) -> bool {
         match Process::new(self.pid()) {
             ProcResult::Ok(prc) => {
-                // assume that the command line and uid don't change during a processes lifetime
+                // assume that the command line, uid and starttime don't change during a processes lifetime
+                // additionally, do not consider defunct processes as "alive"
                 // i.e. if they are different, a new process has the same PID as `self` and so `self` is not considered alive
-                prc.stat.comm == self.stat.comm && prc.owner == self.owner
+                prc.stat.comm == self.stat.comm &&
+                    prc.owner == self.owner &&
+                    prc.stat.starttime == self.stat.starttime &&
+                    prc.stat.state() != ProcState::Zombie &&
+                    self.stat.state() != ProcState::Zombie
             }
             _ => false,
         }


### PR DESCRIPTION
Checking /proc/$pid/stat:starttime to determine whether the process
is the same as the one we cached decreases the chance of misinterpreting
the state of the process. While at it, also make sure that processes that
are zombies ("defunct") are not shown as alive.

Closes: #2 
Signed-off-by: Levente Kurusa <lkurusa@acm.org>