### PR TITLE
use kibibytes to parse meminfo file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,16 @@ fn convert_to_bytes(num: u64, unit: &str) -> u64 {
     }
 }
 
+fn convert_to_kibibytes(num: u64, unit: &str) -> u64 {
+    match unit {
+        "B" => num,
+        "KiB" | "kiB" | "kB" | "KB" => num * 1024,
+        "MiB" | "miB" | "MB" | "mB" => num * 1024 * 1024,
+        "GiB" | "giB" | "GB" | "gB" => num * 1024 * 1024 * 1024,
+        unknown => panic!("Unknown unit type {}", unknown),
+    }
+}
+
 trait FromStrRadix: Sized {
     fn from_str_radix(t: &str, radix: u32) -> Result<Self, std::num::ParseIntError>;
 }

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -13,6 +13,15 @@ use super::{convert_to_kibibytes, ProcResult};
 /// Except as noted below, all of the fields have been present since at least
 /// Linux 2.6.0.  Some fields are optional and are present only if the kernel
 /// was configured with various options; those dependencies are noted in the list.
+///
+/// **Notes**
+///
+/// While the file shows kilobytes (kB; 1 kB equals 1000 B),
+/// it is actually kibibytes (KiB; 1 KiB equals 1024 B).
+///
+/// This imprecision in /proc/meminfo is known,
+/// but is not corrected due to legacy concerns -
+/// programs rely on /proc/meminfo to specify size with the "kB" string.
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct Meminfo {

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::{convert_to_bytes, ProcResult};
+use super::{convert_to_kibibytes, ProcResult};
 
 /// This  struct  reports  statistics about memory usage on the system, based on
 /// the `/proc/meminfo` file.
@@ -70,7 +70,7 @@ pub struct Meminfo {
     /// user-space programs, or for the page cache.  The kernel must use tricks to access this
     /// memory, making it slower to access than lowmem.
     ///
-    /// (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.)  
+    /// (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.)
     pub high_total: Option<u64>,
     /// Amount of free highmem.
     ///
@@ -275,7 +275,7 @@ impl Meminfo {
             let value = from_str!(u64, value);
 
             let value = if let Some(unit) = unit {
-                convert_to_bytes(value, unit)
+                convert_to_kibibytes(value, unit)
             } else {
                 value
             };


### PR DESCRIPTION
As you known, `/proc/meminfo` use `KB` which means kilobytes, but it's typo to kibibyte as [RedHat mentioned](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo). 

> While the file shows kilobytes (kB; 1 kB equals 1000 B), it is actually kibibytes (KiB; 1 KiB equals 1024 B). This imprecision in /proc/meminfo is known, but is not corrected due to legacy concerns - programs rely on /proc/meminfo to specify size with the "kB" string.

There also has [a kernel patch](https://lore.kernel.org/patchwork/patch/666444/) for the issue, but it has been rejected

> Does the difference actually matters so much that we should change a
user visible format of a file? Some users might not ready to changes
(say sombody did sed 's@.*:[[:space:]]*\([0-9]*\) kB@\1@' to get values.
This change would break it which is something we try to prevent as much
as possible.
>
> So I do not think this all is worth the potential troubles. There are
probably other places where we present kB while we in fact think kiB.