### PR TITLE
meminfo.mem_available may exists

### DIFF
--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -370,8 +370,6 @@ mod test {
 
         if kernel >= KernelVersion::new(3, 14, 0) {
             assert!(meminfo.mem_available.is_some());
-        } else {
-            assert!(meminfo.mem_available.is_none());
         }
 
         if kernel >= KernelVersion::new(2, 6, 28) {


### PR DESCRIPTION
As you known, `/proc/meminfo` contains `MemAvailable` since Linux 3.14, but some Linux release may backport it to old kernel.

For example, CentOS 7 have the field with kernel 3.10.0-862.11.6.el7.x86_64

```bash
$ uname -a
Linux localhost.localdomain 3.10.0-862.11.6.el7.x86_64 #1 SMP Tue Aug 14 21:49:04 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

$ cat /proc/meminfo
MemTotal:        1882384 kB
MemFree:          634720 kB
MemAvailable:    1495968 kB
...
```