### PR TITLE
[WIP] extract settings to the layered modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,9 @@ use platform_specific_items::*;
 
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::fmt;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::mem;
 use std::path::Path;
 use std::str::FromStr;
@@ -232,6 +233,29 @@ macro_rules! from_str {
     };
 }
 
+pub(crate) fn read_file<P: AsRef<Path>>(path: P) -> ProcResult<String> {
+    let mut f = proctry!(File::open(path));
+    let mut buf = String::new();
+    proctry!(f.read_to_string(&mut buf));
+    ProcResult::Ok(buf)
+}
+
+pub(crate) fn write_file<P: AsRef<Path>, T: AsRef<[u8]>>(path: P, buf: T) -> ProcResult<()> {
+    let mut f = proctry!(File::open(path));
+    proctry!(f.write_all(buf.as_ref()));
+    ProcResult::Ok(())
+}
+
+pub(crate) fn read_value<P: AsRef<Path>, T: FromStr<Err = E>, E: fmt::Debug>(
+    path: P,
+) -> ProcResult<T> {
+    read_file(path).map(|buf| buf.trim().parse().unwrap())
+}
+
+pub(crate) fn write_value<P: AsRef<Path>, T: fmt::Display>(path: P, value: T) -> ProcResult<()> {
+    write_file(path, value.to_string().as_bytes())
+}
+
 mod process;
 pub use process::*;
 
@@ -247,7 +271,8 @@ pub use cpuinfo::*;
 mod cgroups;
 pub use cgroups::*;
 
-use std::cmp;
+pub mod sys;
+pub use sys::kernel::Version as KernelVersion;
 
 lazy_static! {
     /// The boottime of the system.
@@ -328,91 +353,6 @@ fn split_into_num<T: FromStrRadix>(s: &str, sep: char, radix: u32) -> (T, T) {
     (a, b)
 }
 
-/// Represents a kernel version, in major.minor.release version.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct KernelVersion {
-    pub major: u8,
-    pub minor: u8,
-    pub patch: u8,
-}
-
-impl KernelVersion {
-    pub fn new(major: u8, minor: u8, patch: u8) -> KernelVersion {
-        KernelVersion {
-            major,
-            minor,
-            patch,
-        }
-    }
-
-    /// Returns the kernel version of the curretly running kernel.
-    ///
-    /// This is taken from `/proc/sys/kernel/osrelease`;
-    pub fn current() -> ProcResult<KernelVersion> {
-        let mut f = proctry!(File::open("/proc/sys/kernel/osrelease"));
-        let mut buf = String::new();
-        proctry!(f.read_to_string(&mut buf));
-
-        ProcResult::Ok(KernelVersion::from_str(&buf).unwrap())
-    }
-    /// Parses a kernel version string, in major.minor.release syntax.
-    ///
-    /// Note that any extra information (stuff after a dash) is ignored.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use procfs::KernelVersion;
-    /// let a = KernelVersion::from_str("3.16.0-6-amd64").unwrap();
-    /// let b = KernelVersion::new(3, 16, 0);
-    /// assert_eq!(a, b);
-    ///
-    /// ```
-    pub fn from_str(s: &str) -> Result<KernelVersion, &'static str> {
-        let mut s = s.split('-');
-        let kernel = s.next().unwrap();
-        let mut kernel_split = kernel.split('.');
-
-        let major = kernel_split
-            .next()
-            .ok_or("Missing major version component")?;
-        let minor = kernel_split
-            .next()
-            .ok_or("Missing minor version component")?;
-        let patch = kernel_split
-            .next()
-            .ok_or("Missing patch version component")?;
-
-        let major = major.parse().map_err(|_| "Failed to parse major version")?;
-        let minor = minor.parse().map_err(|_| "Failed to parse minor version")?;
-        let patch = patch.parse().map_err(|_| "Failed to parse patch version")?;
-
-        Ok(KernelVersion {
-            major,
-            minor,
-            patch,
-        })
-    }
-}
-
-impl cmp::Ord for KernelVersion {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        match self.major.cmp(&other.major) {
-            cmp::Ordering::Equal => match self.minor.cmp(&other.minor) {
-                cmp::Ordering::Equal => self.patch.cmp(&other.patch),
-                x => x,
-            },
-            x => x,
-        }
-    }
-}
-
-impl cmp::PartialOrd for KernelVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(&other))
-    }
-}
-
 /// Common result type of procfs operations.
 #[derive(Debug)]
 pub enum ProcResult<T> {
@@ -426,6 +366,17 @@ impl<T> ProcResult<T> {
         match self {
             ProcResult::Ok(_) => true,
             _ => false,
+        }
+    }
+
+    pub fn map<U, F>(self, op: F) -> ProcResult<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            ProcResult::Ok(res) => ProcResult::Ok(op(res)),
+            ProcResult::PermissionDenied => ProcResult::PermissionDenied,
+            ProcResult::NotFound => ProcResult::NotFound,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@
 //!         }
 //!     }
 //! }
-
 #[cfg(unix)]
 extern crate libc;
 #[macro_use]
@@ -136,9 +135,8 @@ use platform_specific_items::*;
 
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::fmt;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::mem;
 use std::path::Path;
 use std::str::FromStr;
@@ -220,28 +218,9 @@ macro_rules! from_str {
     };
 }
 
-pub(crate) fn read_file<P: AsRef<Path>>(path: P) -> ProcResult<String> {
-    let mut f = File::open(path)?;
-    let mut buf = String::new();
-    f.read_to_string(&mut buf)?;
-    Ok(buf)
-}
-
-pub(crate) fn write_file<P: AsRef<Path>, T: AsRef<[u8]>>(path: P, buf: T) -> ProcResult<()> {
-    let mut f = File::open(path)?;
-    f.write_all(buf.as_ref())?;
-    Ok(())
-}
-
-pub(crate) fn read_value<P: AsRef<Path>, T: FromStr<Err = E>, E: fmt::Debug>(
-    path: P,
-) -> ProcResult<T> {
-    read_file(path).map(|buf| buf.trim().parse().unwrap())
-}
-
-pub(crate) fn write_value<P: AsRef<Path>, T: fmt::Display>(path: P, value: T) -> ProcResult<()> {
-    write_file(path, value.to_string().as_bytes())
-}
+#[macro_use]
+mod value;
+pub use value::Value;
 
 mod process;
 pub use process::*;

--- a/src/sys/kernel.rs
+++ b/src/sys/kernel.rs
@@ -6,7 +6,8 @@
 use std::cmp;
 use std::str::FromStr;
 
-use {read_value, ProcResult};
+use value::read_value;
+use ProcResult;
 
 /// Represents a kernel version, in major.minor.release version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/sys/kernel.rs
+++ b/src/sys/kernel.rs
@@ -1,0 +1,112 @@
+//! Global kernel info / tuning miscellaneous stuff
+//!
+//! The files in this directory can be used to tune and monitor miscellaneous
+//! and general things in the operation of the Linux kernel.
+
+use std::cmp;
+use std::str::FromStr;
+
+use {read_value, ProcResult};
+
+/// Represents a kernel version, in major.minor.release version.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Version {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+}
+
+impl Version {
+    pub fn new(major: u8, minor: u8, patch: u8) -> Version {
+        Version {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Returns the kernel version of the curretly running kernel.
+    ///
+    /// This is taken from `/proc/sys/kernel/osrelease`;
+    pub fn current() -> ProcResult<Version> {
+        read_value("/proc/sys/kernel/osrelease")
+    }
+
+    /// Parses a kernel version string, in major.minor.release syntax.
+    ///
+    /// Note that any extra information (stuff after a dash) is ignored.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use procfs::KernelVersion;
+    /// let a = KernelVersion::from_str("3.16.0-6-amd64").unwrap();
+    /// let b = KernelVersion::new(3, 16, 0);
+    /// assert_eq!(a, b);
+    ///
+    /// ```
+    pub fn from_str(s: &str) -> Result<Self, &'static str> {
+        let mut s = s.split('-');
+        let kernel = s.next().unwrap();
+        let mut kernel_split = kernel.split('.');
+
+        let major = kernel_split
+            .next()
+            .ok_or("Missing major version component")?;
+        let minor = kernel_split
+            .next()
+            .ok_or("Missing minor version component")?;
+        let patch = kernel_split
+            .next()
+            .ok_or("Missing patch version component")?;
+
+        let major = major.parse().map_err(|_| "Failed to parse major version")?;
+        let minor = minor.parse().map_err(|_| "Failed to parse minor version")?;
+        let patch = patch.parse().map_err(|_| "Failed to parse patch version")?;
+
+        Ok(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl FromStr for Version {
+    type Err = &'static str;
+
+    /// Parses a kernel version string, in major.minor.release syntax.
+    ///
+    /// Note that any extra information (stuff after a dash) is ignored.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use procfs::KernelVersion;
+    /// let a: KernelVersion = "3.16.0-6-amd64".parse().unwrap();
+    /// let b = KernelVersion::new(3, 16, 0);
+    /// assert_eq!(a, b);
+    ///
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Version::from_str(s)
+    }
+}
+
+impl cmp::Ord for Version {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        match self.major.cmp(&other.major) {
+            cmp::Ordering::Equal => match self.minor.cmp(&other.minor) {
+                cmp::Ordering::Equal => self.patch.cmp(&other.patch),
+                x => x,
+            },
+            x => x,
+        }
+    }
+}
+
+impl cmp::PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,0 +1,10 @@
+//! Sysctl is a means of configuring certain aspects of the kernel at run-time,
+//! and the `/proc/sys/` directory is there so that you don't even need special tools to do it!
+//!
+//! This directory (present since 1.3.57) contains a number of files
+//! and subdirectories corresponding to kernel variables.
+//! These variables can be read and sometimes modified using the `/proc` filesystem,
+//! and the (deprecated) sysctl(2) system call.
+
+pub mod kernel;
+pub mod vm;

--- a/src/sys/vm.rs
+++ b/src/sys/vm.rs
@@ -7,24 +7,20 @@
 use std::fmt;
 use std::str;
 
-use {read_value, write_value, ProcResult};
+use value::write_value;
+use ProcResult;
 
-/// The amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
-///
-/// # Example
-///
-/// ```
-/// use procfs::sys::vm::admin_reserve_kbytes;
-///
-/// assert_ne!(admin_reserve_kbytes().unwrap(), 0);
-/// ```
-pub fn admin_reserve_kbytes() -> ProcResult<usize> {
-    read_value("/proc/sys/vm/admin_reserve_kbytes")
-}
-
-/// Set the amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
-pub fn set_admin_reserve_kbytes(kbytes: usize) -> ProcResult<()> {
-    write_value("/proc/sys/vm/admin_reserve_kbytes", kbytes)
+procfs_value! {
+    /// The amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use procfs::sys::vm::admin_reserve_kbytes;
+    ///
+    /// assert_ne!(admin_reserve_kbytes().unwrap().get().unwrap(), 0);
+    /// ```
+    admin_reserve_kbytes: usize;
 }
 
 /// Force all zones are compacted such that free memory is available in contiguous blocks where possible.
@@ -85,36 +81,43 @@ impl str::FromStr for DropCache {
     }
 }
 
-/// Causes the kernel to drop clean caches, dentries, and inodes from memory,
-/// causing that memory to become free.
-///
-/// This can be useful for memory management testing and performing reproducible filesystem benchmarks.
-/// Because writing to this file causes the benefits of caching to be lost,
-/// it can degrade overall system performance.
-pub fn drop_caches(drop: DropCache) -> ProcResult<()> {
-    write_value("/proc/sys/vm/drop_caches", drop)
-}
+procfs_value! {
+    /// Causes the kernel to drop clean caches, dentries, and inodes from memory,
+    /// causing that memory to become free.
+    ///
+    /// This can be useful for memory management testing and performing reproducible filesystem benchmarks.
+    /// Because writing to this file causes the benefits of caching to be lost,
+    /// it can degrade overall system performance.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use procfs::sys::vm::{drop_caches, DropCache};
+    ///
+    /// if let Ok(drop_caches) = drop_caches() {
+    ///     if drop_caches.writeable() {
+    ///         drop_caches.set(DropCache::Default).unwrap();
+    ///     }
+    /// }
+    /// ```
+    @writeonly
+    drop_caches: DropCache;
 
-/// The maximum number of memory map areas a process may have.
-///
-/// Memory map areas are used as a side-effect of calling malloc,
-/// directly by mmap, mprotect, and madvise, and also when loading shared libraries.
-///
-/// # Example
-///
-/// ```
-/// use procfs::sys::vm::max_map_count;
-///
-/// assert_ne!(max_map_count().unwrap(), 0);
-/// ```
-pub fn max_map_count() -> ProcResult<u64> {
-    read_value("/proc/sys/vm/max_map_count")
-}
+    /// The maximum number of memory map areas a process may have.
+    ///
+    /// Memory map areas are used as a side-effect of calling malloc,
+    /// directly by mmap, mprotect, and madvise, and also when loading shared libraries.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use procfs::sys::vm::max_map_count;
+    ///
+    /// assert_ne!(max_map_count().unwrap().get().unwrap(), 0);
+    /// ```
+    max_map_count: u64;
 
-/// Set the maximum number of memory map areas a process may have.
-///
-/// Memory map areas are used as a side-effect of calling malloc,
-/// directly by mmap, mprotect, and madvise, and also when loading shared libraries.
-pub fn set_max_map_count(count: u64) -> ProcResult<()> {
-    write_value("/proc/sys/vm/max_map_count", count)
+    /// If nonzero, this disables the new 32-bit memory-mapping layout;
+    /// the kernel will use the legacy (2.4) layout for all processes.
+    legacy_va_layout: isize;
 }

--- a/src/sys/vm.rs
+++ b/src/sys/vm.rs
@@ -1,0 +1,120 @@
+//! Memory management tuning buffer and cache management
+//!
+//! The files in this directory can be used to tune
+//! the operation of the virtual memory (VM) subsystem of the Linux kernel
+//! and the write out of dirty data to disk.
+
+use std::fmt;
+use std::str;
+
+use {read_value, write_value, ProcResult};
+
+/// The amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
+///
+/// # Example
+///
+/// ```
+/// use procfs::sys::vm::admin_reserve_kbytes;
+///
+/// assert_ne!(admin_reserve_kbytes().unwrap(), 0);
+/// ```
+pub fn admin_reserve_kbytes() -> ProcResult<usize> {
+    read_value("/proc/sys/vm/admin_reserve_kbytes")
+}
+
+/// Set the amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
+pub fn set_admin_reserve_kbytes(kbytes: usize) -> ProcResult<()> {
+    write_value("/proc/sys/vm/admin_reserve_kbytes", kbytes)
+}
+
+/// Force all zones are compacted such that free memory is available in contiguous blocks where possible.
+///
+/// This can be important for example in the allocation of huge pages
+/// although processes will also directly compact memory as required.
+///
+/// Present only if the kernel was configured with CONFIG_COMPACTION.
+pub fn compact_memory() -> ProcResult<()> {
+    write_value("/proc/sys/vm/compact_memory", 1)
+}
+
+/// drop clean caches, dentries, and inodes from memory, causing that memory to become free.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DropCache {
+    /// default
+    Default = 0,
+    /// free pagecache
+    PageCache = 1,
+    /// free dentries and inodes
+    Inodes = 2,
+    /// free pagecache, dentries and inodes
+    All = 3,
+    /// disable
+    Disable = 4,
+}
+
+impl fmt::Display for DropCache {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                DropCache::Default => 0,
+                DropCache::PageCache => 1,
+                DropCache::Inodes => 2,
+                DropCache::All => 3,
+                DropCache::Disable => 4,
+            }
+        )
+    }
+}
+
+impl str::FromStr for DropCache {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse()
+            .map_err(|_| "Fail to parse drop cache")
+            .and_then(|n| match n {
+                0 => Ok(DropCache::Default),
+                1 => Ok(DropCache::PageCache),
+                2 => Ok(DropCache::Inodes),
+                3 => Ok(DropCache::All),
+                4 => Ok(DropCache::Disable),
+                _ => Err("Unknown drop cache value"),
+            })
+    }
+}
+
+/// Causes the kernel to drop clean caches, dentries, and inodes from memory,
+/// causing that memory to become free.
+///
+/// This can be useful for memory management testing and performing reproducible filesystem benchmarks.
+/// Because writing to this file causes the benefits of caching to be lost,
+/// it can degrade overall system performance.
+pub fn drop_caches(drop: DropCache) -> ProcResult<()> {
+    write_value("/proc/sys/vm/drop_caches", drop)
+}
+
+/// The maximum number of memory map areas a process may have.
+///
+/// Memory map areas are used as a side-effect of calling malloc,
+/// directly by mmap, mprotect, and madvise, and also when loading shared libraries.
+///
+/// # Example
+///
+/// ```
+/// use procfs::sys::vm::max_map_count;
+///
+/// assert_ne!(max_map_count().unwrap(), 0);
+/// ```
+pub fn max_map_count() -> ProcResult<u64> {
+    read_value("/proc/sys/vm/max_map_count")
+}
+
+/// Set the maximum number of memory map areas a process may have.
+///
+/// Memory map areas are used as a side-effect of calling malloc,
+/// directly by mmap, mprotect, and madvise, and also when loading shared libraries.
+pub fn set_max_map_count(count: u64) -> ProcResult<()> {
+    write_value("/proc/sys/vm/max_map_count", count)
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,180 @@
+use std::ffi::CString;
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use libc;
+
+use {ProcError, ProcResult};
+
+pub fn read_file<P: AsRef<Path>>(path: P) -> ProcResult<String> {
+    let mut f = File::open(path)?;
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
+pub fn write_file<P: AsRef<Path>, T: AsRef<[u8]>>(path: P, buf: T) -> ProcResult<()> {
+    let mut f = File::open(path)?;
+    f.write_all(buf.as_ref())?;
+    Ok(())
+}
+
+pub fn read_value<P: AsRef<Path>, T: FromStr<Err = E>, E: fmt::Debug>(path: P) -> ProcResult<T> {
+    read_file(path).map(|buf| buf.trim().parse().unwrap())
+}
+
+pub fn write_value<P: AsRef<Path>, T: fmt::Display>(path: P, value: T) -> ProcResult<()> {
+    write_file(path, value.to_string().as_bytes())
+}
+
+pub fn access<P: AsRef<Path>>(path: P, mode: i32) -> bool {
+    unsafe {
+        libc::access(
+            CString::new(path.as_ref().as_os_str().as_bytes())
+                .unwrap()
+                .as_ptr(),
+            mode,
+        ) == 0
+    }
+}
+
+pub trait Readable<T, E>
+where
+    T: FromStr<Err = E>,
+    E: fmt::Debug,
+{
+    fn read<P: AsRef<Path>>(path: P) -> ProcResult<T> {
+        let path = path.as_ref();
+
+        if access(path, libc::R_OK) {
+            read_value(path)
+        } else {
+            Err(ProcError::PermissionDenied)
+        }
+    }
+}
+
+pub trait Writeable<T>
+where
+    T: fmt::Display,
+{
+    fn write<P: AsRef<Path>>(path: P, value: T) -> ProcResult<()> {
+        let path = path.as_ref();
+
+        if access(path, libc::W_OK) {
+            write_value(path, value)
+        } else {
+            Err(ProcError::PermissionDenied)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReadOnly {}
+
+impl<T, E> Readable<T, E> for ReadOnly
+where
+    T: FromStr<Err = E>,
+    E: fmt::Debug,
+{
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct WriteOnly {}
+
+impl<T> Writeable<T> for WriteOnly where T: fmt::Display {}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReadWrite {}
+
+impl<T, E> Readable<T, E> for ReadWrite
+where
+    T: FromStr<Err = E>,
+    E: fmt::Debug,
+{
+}
+
+impl<T> Writeable<T> for ReadWrite where T: fmt::Display {}
+
+#[derive(Clone, Debug)]
+pub struct Value<T, M> {
+    path: PathBuf,
+    phantom: PhantomData<(T, M)>,
+}
+
+impl<T, M> Value<T, M> {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        Value {
+            path: path.into(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, E, M> Value<T, M>
+where
+    T: FromStr<Err = E>,
+    E: fmt::Debug,
+    M: Readable<T, E>,
+{
+    pub fn readable(&self) -> bool {
+        access(&self.path, libc::R_OK)
+    }
+
+    pub fn get(&self) -> ProcResult<T> {
+        M::read(&self.path)
+    }
+}
+
+impl<T, M> Value<T, M>
+where
+    T: fmt::Display,
+    M: Writeable<T>,
+{
+    pub fn writeable(&self) -> bool {
+        access(&self.path, libc::W_OK)
+    }
+
+    pub fn set(&self, value: T) -> ProcResult<()> {
+        M::write(&self.path, value)
+    }
+}
+
+#[macro_export]
+macro_rules! procfs_value {
+    (__impl $(#[$attr:meta])* $name:ident : $ty:ty ; $mode:ident) => {
+        $(#[$attr])*
+        pub fn $name() -> ProcResult<$crate::value::Value<$ty, $crate::value::$mode>> {
+            let path = module_path!().trim_left_matches("procfs::").replace("::", "/");
+            let path = ::std::path::Path::new("/proc").join(path).join(stringify!($name));
+
+            if path.exists() {
+                Ok($crate::value::Value::new(path))
+            } else {
+                Err($crate::ProcError::NotFound)
+            }
+        }
+    };
+    ($(#[$attr:meta])* @readwrite $name:ident : $ty:ty ; $($rest:tt)*) => {
+        procfs_value!(__impl $(#[$attr])* $name : $ty ; ReadWrite);
+        procfs_value!($($rest)*);
+    };
+    ($(#[$attr:meta])* @readonly $name:ident : $ty:ty ; $($rest:tt)*) => {
+        procfs_value!(__impl $(#[$attr])* $name : $ty ; ReadOnly);
+        procfs_value!($($rest)*);
+    };
+    ($(#[$attr:meta])* @writeonly $name:ident : $ty:ty ; $($rest:tt)*) => {
+        procfs_value!(__impl $(#[$attr])* $name : $ty ; WriteOnly);
+        procfs_value!($($rest)*);
+    };
+    ($(#[$attr:meta])* $name:ident : $ty:ty ; $($rest:tt)*) => {
+        procfs_value!(__impl $(#[$attr])* $name : $ty ; ReadWrite);
+        procfs_value!($($rest)*);
+    };
+    () => {}
+}


### PR DESCRIPTION
As you known, the `procfs` has hundreds of setting files, we hard to list all of them in the root namespace.

I propose to use a layered modules base on the `procfs` folder, for example

```rust
use procfs::sys::vm::admin_reserve_kbytes;

assert_ne!(admin_reserve_kbytes().unwrap(), 0);
```