### PR TITLE
WIP: /proc/<pid>/mountstats parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,9 +437,6 @@ impl From<std::io::Error> for ProcError {
 }
 
 
-trait ProcFrom<T> {
-    fn from(s: T) -> Self;
-}
 
 /// Load average figures.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,35 +188,39 @@ macro_rules! expect {
 #[macro_use]
 macro_rules! from_str {
     ($t:tt, $e:expr) => {
-        $t::from_str_radix($e, 10).unwrap_or_else(|_| {
+        {let e = $e;
+        $t::from_str_radix(e, 10).unwrap_or_else(|_| {
             panic!(
                 "Failed to parse {} ({:?}) as a {}. Please report this as a procfs bug.",
                 stringify!($e),
-                $e,
-                stringify!($t)
+                e,
+                stringify!($t),
             )
-        })
+        })}
+
     };
     ($t:tt, $e:expr, $radix:expr) => {
-        $t::from_str_radix($e, $radix).unwrap_or_else(|_| {
+        {let e = $e;
+        $t::from_str_radix(e, $radix).unwrap_or_else(|_| {
             panic!(
                 "Failed to parse {} ({:?}) as a {}. Please report this as a procfs bug.",
                 stringify!($e),
-                $e,
+                e,
                 stringify!($t)
             )
-        })
+        })}
     };
     ($t:tt, $e:expr, $radix:expr, pid:$pid:expr) => {
-        $t::from_str_radix($e, $radix).unwrap_or_else(|_| {
+        {let e = $e;
+        $t::from_str_radix(e, $radix).unwrap_or_else(|_| {
             panic!(
                 "Failed to parse {} ({:?}) as a {} (pid {}). Please report this as a procfs bug.",
                 stringify!($e),
-                $e,
+                e,
                 stringify!($t),
                 $pid
             )
-        })
+        })}
     };
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -448,7 +448,8 @@ pub struct Io {
 }
 
 /// Mount information from `/proc/<pid>/mountstats`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct MountStat {
     pub device: Option<String>,
     pub mount_point: PathBuf,
@@ -498,7 +499,8 @@ impl MountStat {
 }
 
 /// Only NFS mounts provide additional statistics in `MountStat` entries.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct MountNFSStatistics {
     pub version: String,
     // * opts: HashMap<String, Some(String)>
@@ -570,7 +572,8 @@ impl MountNFSStatistics {
 /// The underlying data structure in the kernel can be found under *fs/nfs/iostat.h* `nfs_iostat`.
 /// The fields are documented in the kernel source only under *include/linux/nfs_iostat.h* `enum
 /// nfs_stat_eventcounters`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NFSEventCounter {
     inode_revalidate: libc::c_ulong,
     deny_try_revalidate: libc::c_ulong,
@@ -642,7 +645,8 @@ impl NFSEventCounter {
 /// The underlying data structure in the kernel can be found under *fs/nfs/iostat.h* `nfs_iostat`.
 /// The fields are documented in the kernel source only under *include/linux/nfs_iostat.h* `enum
 /// nfs_stat_bytecounters`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NFSByteCounter {
     pub normal_read: libc::c_ulonglong,
     pub normal_write: libc::c_ulonglong,
@@ -700,7 +704,8 @@ impl NFSByteCounter {
 /// >  are measured.
 ///
 /// (source: *include/linux/sunrpc/metrics.h* `struct rpc_iostats`)
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct NFSOperationStat {
     /// Count of rpc operations.
     pub operations: libc::c_ulong,

--- a/src/process.rs
+++ b/src/process.rs
@@ -450,10 +450,10 @@ pub struct Io {
 /// Mount information from `/proc/<pid>/mountstats`.
 #[derive(Debug, PartialEq)]
 pub struct MountStat {
-    device: Option<String>,
-    mount_point: PathBuf,
-    fs: String,
-    statistics: Option<MountNFSStatistics>,
+    pub device: Option<String>,
+    pub mount_point: PathBuf,
+    pub fs: String,
+    pub statistics: Option<MountNFSStatistics>,
 }
 
 impl MountStat {
@@ -500,10 +500,10 @@ impl MountStat {
 /// Only NFS mounts provide additional statistics in `MountStat` entries.
 #[derive(Debug, PartialEq)]
 pub struct MountNFSStatistics {
-    version: String,
+    pub version: String,
     // * opts: HashMap<String, Some(String)>
     /// Duration the NFS mount has been in existence.
-    age: Duration,
+    pub age: Duration,
     // * fsc (?)
     // * impl_id (NFSv4): Option<HashMap<String, Some(String)>>
     // * caps: HashMap<String, String>
@@ -514,7 +514,7 @@ pub struct MountNFSStatistics {
     // * RPC iostats version:
     // * xprt
     // * per-op statistics
-    per_op_stats: NFSPerOpStats,
+    pub per_op_stats: NFSPerOpStats,
 }
 
 impl MountNFSStatistics {

--- a/src/process.rs
+++ b/src/process.rs
@@ -601,52 +601,54 @@ pub struct NFSByteCounter {
     // * pages_write
 }
 
+/// Represents NFS data from `/proc/<pid>/mountstats` under the section of `per-op statistics`.
+///
 /// Here is what the Kernel says about the attributes:
 ///
 /// Regarding `operations`, `transmissions` and `major_timeouts`:
 ///
-///    These counters give an idea about how many request
-///    transmissions are required, on average, to complete that
-///    particular procedure.  Some procedures may require more
-///    than one transmission because the server is unresponsive,
-///    the client is retransmitting too aggressively, or the
-///    requests are large and the network is congested.
+/// >  These counters give an idea about how many request
+/// >  transmissions are required, on average, to complete that
+/// >  particular procedure.  Some procedures may require more
+/// >  than one transmission because the server is unresponsive,
+/// >  the client is retransmitting too aggressively, or the
+/// >  requests are large and the network is congested.
 ///
 /// Regarding `bytes_sent` and `bytes_recv`:
 ///
-///    These count how many bytes are sent and received for a
-///    given RPC procedure type.  This indicates how much load a
-///    particular procedure is putting on the network.  These
-///    counts include the RPC and ULP headers, and the request
-///    payload.
+/// >  These count how many bytes are sent and received for a
+/// >  given RPC procedure type.  This indicates how much load a
+/// >  particular procedure is putting on the network.  These
+/// >  counts include the RPC and ULP headers, and the request
+/// >  payload.
 ///
 /// Regarding `cum_queue_time`, `cum_resp_time` and `cum_total_req_time`:
 ///
-///    The length of time an RPC request waits in queue before
-///    transmission, the network + server latency of the request,
-///    and the total time the request spent from init to release
-///    are measured.
+/// >  The length of time an RPC request waits in queue before
+/// >  transmission, the network + server latency of the request,
+/// >  and the total time the request spent from init to release
+/// >  are measured.
 ///
 /// (source: *include/linux/sunrpc/metrics.h* `struct rpc_iostats`)
 #[derive(Debug, PartialEq)]
 pub struct NFSOperationStat {
     /// Count of rpc operations.
-    operations: libc::c_ulong,
+    pub operations: libc::c_ulong,
     /// Count of rpc transmissions
-    transmissions: libc::c_ulong,
+    pub transmissions: libc::c_ulong,
     /// Count of rpc major timeouts
-    major_timeouts: libc::c_ulong,
+    pub major_timeouts: libc::c_ulong,
     /// Count of bytes send. Does not only include the RPC payload but the RPC headers as well.
-    bytes_sent: libc::c_ulonglong,
+    pub bytes_sent: libc::c_ulonglong,
     /// Count of bytes received as `bytes_sent`.
-    bytes_recv: libc::c_ulonglong,
+    pub bytes_recv: libc::c_ulonglong,
     /// How long all requests have spend in the queue before being send.
-    cum_queue_time: Duration,
+    pub cum_queue_time: Duration,
     /// How long it took to get a response back.
-    cum_resp_time: Duration,
+    pub cum_resp_time: Duration,
     /// How long all requests have taken from beeing queued to the point they where completely
     /// handled.
-    cum_total_req_time: Duration,
+    pub cum_total_req_time: Duration,
 }
 
 impl NFSOperationStat {

--- a/src/process.rs
+++ b/src/process.rs
@@ -804,7 +804,8 @@ impl NFSOperationStat {
         let major_timeouts = from_str!(c_ulong, expect!(s.next()));
         let bytes_sent = from_str!(c_ulonglong, expect!(s.next()));
         let bytes_recv = from_str!(c_ulonglong, expect!(s.next()));
-        let cum_queue_time_ms = from_str!(i64, expect!(s.next()));
+        // TODO: on my system, the following value overflows an i64!
+        let cum_queue_time_ms = from_str!(u64, expect!(s.next()));
         let cum_resp_time_ms = from_str!(i64, expect!(s.next()));
         let cum_total_req_time_ms = from_str!(i64, expect!(s.next()));
         if cum_queue_time_ms < 0 {

--- a/src/process.rs
+++ b/src/process.rs
@@ -519,8 +519,6 @@ impl MountStat {
                     fs,
                     statistics
                 });
-            } else {
-                println!("Skipping line {}", line);
             }
         }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -137,18 +137,17 @@ bitflags! {
 //    }
 //}
 
-impl<'a, I, U> ProcFrom<I> for U
+
+fn from_iter<'a, I, U>(i: I) -> U
 where
-    I: IntoIterator<Item = &'a str>,
-    U: FromStr,
+I: IntoIterator<Item = &'a str>,
+U: FromStr,
 {
-    fn from(i: I) -> U {
-        let mut iter = i.into_iter();
-        let val = expect!(iter.next(), "Missing iterator next item");
-        match FromStr::from_str(val) {
-            Ok(u) => u,
-            Err(..) => panic!("Failed to convert".to_string()),
-        }
+    let mut iter = i.into_iter();
+    let val = expect!(iter.next(), "Missing iterator next item");
+    match FromStr::from_str(val) {
+        Ok(u) => u,
+        Err(..) => panic!("Failed to convert".to_string()),
     }
 }
 
@@ -1016,56 +1015,56 @@ impl Stat {
         let mut rest = rest.split(' ');
         let state = rest.next().unwrap().chars().next().unwrap();
 
-        let ppid = ProcFrom::from(&mut rest);
-        let pgrp = ProcFrom::from(&mut rest);
-        let session = ProcFrom::from(&mut rest);
-        let tty_nr = ProcFrom::from(&mut rest);
-        let tpgid = ProcFrom::from(&mut rest);
-        let flags = ProcFrom::from(&mut rest);
-        let minflt = ProcFrom::from(&mut rest);
-        let cminflt = ProcFrom::from(&mut rest);
-        let majflt = ProcFrom::from(&mut rest);
-        let cmajflt = ProcFrom::from(&mut rest);
-        let utime = ProcFrom::from(&mut rest);
-        let stime = ProcFrom::from(&mut rest);
-        let cutime = ProcFrom::from(&mut rest);
-        let cstime = ProcFrom::from(&mut rest);
-        let priority = ProcFrom::from(&mut rest);
-        let nice = ProcFrom::from(&mut rest);
-        let num_threads = ProcFrom::from(&mut rest);
-        let itrealvalue = ProcFrom::from(&mut rest);
-        let starttime = ProcFrom::from(&mut rest);
-        let vsize = ProcFrom::from(&mut rest);
-        let rss = ProcFrom::from(&mut rest);
-        let rsslim = ProcFrom::from(&mut rest);
-        let startcode = ProcFrom::from(&mut rest);
-        let endcode = ProcFrom::from(&mut rest);
-        let startstack = ProcFrom::from(&mut rest);
-        let kstkesp = ProcFrom::from(&mut rest);
-        let kstkeip = ProcFrom::from(&mut rest);
-        let signal = ProcFrom::from(&mut rest);
-        let blocked = ProcFrom::from(&mut rest);
-        let sigignore = ProcFrom::from(&mut rest);
-        let sigcatch = ProcFrom::from(&mut rest);
-        let wchan = ProcFrom::from(&mut rest);
-        let nswap = ProcFrom::from(&mut rest);
-        let cnswap = ProcFrom::from(&mut rest);
+        let ppid = from_iter(&mut rest);
+        let pgrp = from_iter(&mut rest);
+        let session = from_iter(&mut rest);
+        let tty_nr = from_iter(&mut rest);
+        let tpgid = from_iter(&mut rest);
+        let flags = from_iter(&mut rest);
+        let minflt = from_iter(&mut rest);
+        let cminflt = from_iter(&mut rest);
+        let majflt = from_iter(&mut rest);
+        let cmajflt = from_iter(&mut rest);
+        let utime = from_iter(&mut rest);
+        let stime = from_iter(&mut rest);
+        let cutime = from_iter(&mut rest);
+        let cstime = from_iter(&mut rest);
+        let priority = from_iter(&mut rest);
+        let nice = from_iter(&mut rest);
+        let num_threads = from_iter(&mut rest);
+        let itrealvalue = from_iter(&mut rest);
+        let starttime = from_iter(&mut rest);
+        let vsize = from_iter(&mut rest);
+        let rss = from_iter(&mut rest);
+        let rsslim = from_iter(&mut rest);
+        let startcode = from_iter(&mut rest);
+        let endcode = from_iter(&mut rest);
+        let startstack = from_iter(&mut rest);
+        let kstkesp = from_iter(&mut rest);
+        let kstkeip = from_iter(&mut rest);
+        let signal = from_iter(&mut rest);
+        let blocked = from_iter(&mut rest);
+        let sigignore = from_iter(&mut rest);
+        let sigcatch = from_iter(&mut rest);
+        let wchan = from_iter(&mut rest);
+        let nswap = from_iter(&mut rest);
+        let cnswap = from_iter(&mut rest);
 
-        let exit_signal = since_kernel!(2, 1, 22, ProcFrom::from(&mut rest));
-        let processor = since_kernel!(2, 2, 8, ProcFrom::from(&mut rest));
-        let rt_priority = since_kernel!(2, 5, 19, ProcFrom::from(&mut rest));
-        let policy = since_kernel!(2, 5, 19, ProcFrom::from(&mut rest));
-        let delayacct_blkio_ticks = since_kernel!(2, 6, 18, ProcFrom::from(&mut rest));
-        let guest_time = since_kernel!(2, 6, 24, ProcFrom::from(&mut rest));
-        let cguest_time = since_kernel!(2, 6, 24, ProcFrom::from(&mut rest));
-        let start_data = since_kernel!(3, 3, 0, ProcFrom::from(&mut rest));
-        let end_data = since_kernel!(3, 3, 0, ProcFrom::from(&mut rest));
-        let start_brk = since_kernel!(3, 3, 0, ProcFrom::from(&mut rest));
-        let arg_start = since_kernel!(3, 5, 0, ProcFrom::from(&mut rest));
-        let arg_end = since_kernel!(3, 5, 0, ProcFrom::from(&mut rest));
-        let env_start = since_kernel!(3, 5, 0, ProcFrom::from(&mut rest));
-        let env_end = since_kernel!(3, 5, 0, ProcFrom::from(&mut rest));
-        let exit_code = since_kernel!(3, 5, 0, ProcFrom::from(&mut rest));
+        let exit_signal = since_kernel!(2, 1, 22, from_iter(&mut rest));
+        let processor = since_kernel!(2, 2, 8, from_iter(&mut rest));
+        let rt_priority = since_kernel!(2, 5, 19, from_iter(&mut rest));
+        let policy = since_kernel!(2, 5, 19, from_iter(&mut rest));
+        let delayacct_blkio_ticks = since_kernel!(2, 6, 18, from_iter(&mut rest));
+        let guest_time = since_kernel!(2, 6, 24, from_iter(&mut rest));
+        let cguest_time = since_kernel!(2, 6, 24, from_iter(&mut rest));
+        let start_data = since_kernel!(3, 3, 0, from_iter(&mut rest));
+        let end_data = since_kernel!(3, 3, 0, from_iter(&mut rest));
+        let start_brk = since_kernel!(3, 3, 0, from_iter(&mut rest));
+        let arg_start = since_kernel!(3, 5, 0, from_iter(&mut rest));
+        let arg_end = since_kernel!(3, 5, 0, from_iter(&mut rest));
+        let env_start = since_kernel!(3, 5, 0, from_iter(&mut rest));
+        let env_end = since_kernel!(3, 5, 0, from_iter(&mut rest));
+        let exit_code = since_kernel!(3, 5, 0, from_iter(&mut rest));
 
         Some(Stat {
             pid,

--- a/src/process.rs
+++ b/src/process.rs
@@ -804,19 +804,9 @@ impl NFSOperationStat {
         let major_timeouts = from_str!(c_ulong, expect!(s.next()));
         let bytes_sent = from_str!(c_ulonglong, expect!(s.next()));
         let bytes_recv = from_str!(c_ulonglong, expect!(s.next()));
-        // TODO: on my system, the following value overflows an i64!
         let cum_queue_time_ms = from_str!(u64, expect!(s.next()));
-        let cum_resp_time_ms = from_str!(i64, expect!(s.next()));
-        let cum_total_req_time_ms = from_str!(i64, expect!(s.next()));
-        if cum_queue_time_ms < 0 {
-            panic!("Got a negative duration on cum_queue_time, this unexpected. Please report this error.");
-        }
-        if cum_resp_time_ms < 0 {
-            panic!("Got a negative duration on cum_resp_time, this unexpected. Please report this error.");
-        }
-        if cum_total_req_time_ms < 0 {
-            panic!("Got a negative duration on cum_total_req_time, this unexpected. Please report this error.");
-        }
+        let cum_resp_time_ms = from_str!(u64, expect!(s.next()));
+        let cum_total_req_time_ms = from_str!(u64, expect!(s.next()));
 
         NFSOperationStat {
             operations: operations,
@@ -824,9 +814,9 @@ impl NFSOperationStat {
             major_timeouts: major_timeouts,
             bytes_sent: bytes_sent,
             bytes_recv: bytes_recv,
-            cum_queue_time: Duration::from_millis(cum_queue_time_ms as u64),
-            cum_resp_time: Duration::from_millis(cum_resp_time_ms as u64),
-            cum_total_req_time: Duration::from_millis(cum_total_req_time_ms as u64),
+            cum_queue_time: Duration::from_millis(cum_queue_time_ms),
+            cum_resp_time: Duration::from_millis(cum_resp_time_ms),
+            cum_total_req_time: Duration::from_millis(cum_total_req_time_ms),
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -531,6 +531,9 @@ impl MountStat {
 }
 
 /// Only NFS mounts provide additional statistics in `MountStat` entries.
+//
+// Thank you to Chris Siebenmann for their helpful work in documenting these structures:
+// https://utcc.utoronto.ca/~cks/space/blog/linux/NFSMountstatsIndex
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct MountNFSStatistics {
@@ -1514,17 +1517,20 @@ mod tests {
     #[test]
     fn test_all() {
         for prc in all_processes() {
-            prc.stat.flags();
-            prc.stat.starttime();
-            prc.cmdline();
-            prc.environ();
-            prc.fd();
-            prc.io();
-            prc.maps();
-            prc.coredump_filter();
-            prc.autogroup();
-            prc.auxv();
-            prc.cgroups();
+            // note: this test doesn't unwrap, since some of this data requires root to access
+            // so permission denied errors are common
+            // TODO unwrap but allow for permission denied errors in this test
+            let _ = prc.stat.flags();
+            let _ = prc.stat.starttime();
+            let _ = prc.cmdline();
+            let _ = prc.environ();
+            let _ = prc.fd();
+            let _ = prc.io();
+            let _ = prc.maps();
+            let _ = prc.coredump_filter();
+            let _ = prc.autogroup();
+            let _ = prc.auxv();
+            let _ = prc.cgroups();
         }
     }
 


### PR DESCRIPTION
After an initial [conversation on twitter](https://twitter.com/thatcks/status/1046831996293566464) with  Chris Siebenmann about `/proc/<pid>/moutstats` it appears to be a good time to implement a parser for that into `procfs`. 

The basics are pretty easy to parse, but if you have an NFS filesystem the topic not as good documented. Fortunately Chris Siebenmann has written some [blog posts](https://utcc.utoronto.ca/~cks/space/blog/linux/NFSMountstatsIndex) about that a while back.

I've already done some work on the data structures and written a basic test.

# Overview Todo

 1. Finish and validate the datastructures
 2. Include documentation for every field since most fields are not coverd by `proc(5)`
 3. Implement a parser for regular filesystems
 4. Implement a parser for the NFS stat formats `1.0` and `1.1`

# Questions

 1. Some fields (like `opts`) do have a key-value, key-only structure. How should those field be handled? I do see three possible option about how to handle that:
    1. Provide those with `String` only. This is easy and the user needs to manage the parsing according to his own needs
    2. `Vec<String>` in which the settings are already split by `,`. This provides in my opinion no advantage over the first option
    3. A key-value data structure where its possible to loopup if a setting is **present**, if the setting **has a value** and the **content** of the value. My first impression was to use a `HashMap<String, Option<String>>` but I am unsure about the ergonomics. Take the following example into account:

```rust
// opts containing "rw,vers=4.1,rsize=131072"
let opts: HashMap<String, Option<String>> = stat.opts;
// key only setting
match opts.get("rw") {
    Some(None) => println!("rw is set"),
    None => println!("rw is not set"),
    Some(Some(_)) => panic!("rw should have no values"),
}
// read key-value setting
match opts.get("vers") {
    Some(Some(vers)) => println!("NFS version: {}", vers),
    Some(None) => panic!("expected version in 'vers' option"),
    None => println!("NFS version is not explicitly set"),
}
```
  2. The fitting integer values for many values are currently missing. I guess there is some kernel ready in order to determine that.

  3. Regarding the `per-op statistics`: My current approach is a relative general parsing aproach, it would also possible to define a type for every `per-op` line like `NULL`. It seems that every `statvers` does provide a different set of option. I would prefere the general aproach, but maybe there are other opinions.