### PR TITLE
ProcError improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ chrono = "0.4"
 byteorder = {version="1", features=["i128"]}
 hex = "0.3"
 libflate = "0.1"
+
+[dev-dependencies]
+failure = "*"

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::{convert_to_kibibytes, ProcResult};
+use super::{convert_to_kibibytes, ProcResult, FileWrapper};
 
 /// This  struct  reports  statistics about memory usage on the system, based on
 /// the `/proc/meminfo` file.
@@ -259,7 +259,7 @@ impl Meminfo {
     pub fn new() -> ProcResult<Meminfo> {
         use std::fs::File;
 
-        let f = File::open("/proc/meminfo")?;
+        let f = FileWrapper::open("/proc/meminfo")?;
 
         Ok(Meminfo::from_reader(f))
     }

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::{convert_to_kibibytes, ProcResult, FileWrapper};
+use super::{convert_to_kibibytes, FileWrapper, ProcResult};
 
 /// This  struct  reports  statistics about memory usage on the system, based on
 /// the `/proc/meminfo` file.
@@ -257,8 +257,6 @@ impl Meminfo {
     /// This may panic if expected fields are missing.  This can happen when running on kernels
     /// older than 2.6.0.
     pub fn new() -> ProcResult<Meminfo> {
-        use std::fs::File;
-
         let f = FileWrapper::open("/proc/meminfo")?;
 
         Ok(Meminfo::from_reader(f))

--- a/src/net.rs
+++ b/src/net.rs
@@ -4,6 +4,7 @@ use byteorder::{ByteOrder, NetworkEndian};
 use hex;
 use std::io::{BufRead, BufReader, Read};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use crate::FileWrapper;
 
 #[derive(Debug, PartialEq)]
 pub enum TcpState {
@@ -180,7 +181,7 @@ fn read_udp_table<R: Read>(reader: BufReader<R>) -> ProcResult<Vec<UdpNetEntry>>
 /// Reads the tcp socket table
 pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
     use std::fs::File;
-    let file = File::open("/proc/net/tcp")?;
+    let file = FileWrapper::open("/proc/net/tcp")?;
 
     read_tcp_table(BufReader::new(file))
 }
@@ -188,7 +189,7 @@ pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
 /// Reads the tcp6 socket table
 pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
     use std::fs::File;
-    let file = File::open("/proc/net/tcp6")?;
+    let file = FileWrapper::open("/proc/net/tcp6")?;
 
     read_tcp_table(BufReader::new(file))
 }
@@ -196,7 +197,7 @@ pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
 /// Reads the udp socket table
 pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
     use std::fs::File;
-    let file = File::open("/proc/net/udp")?;
+    let file = FileWrapper::open("/proc/net/udp")?;
 
     read_udp_table(BufReader::new(file))
 }
@@ -204,7 +205,7 @@ pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
 /// Reads the udp6 socket table
 pub fn udp6() -> ProcResult<Vec<UdpNetEntry>> {
     use std::fs::File;
-    let file = File::open("/proc/net/udp6")?;
+    let file = FileWrapper::open("/proc/net/udp6")?;
 
     read_udp_table(BufReader::new(file))
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,10 +1,10 @@
 use ProcResult;
 
+use crate::FileWrapper;
 use byteorder::{ByteOrder, NetworkEndian};
 use hex;
 use std::io::{BufRead, BufReader, Read};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use crate::FileWrapper;
 
 #[derive(Debug, PartialEq)]
 pub enum TcpState {
@@ -180,7 +180,6 @@ fn read_udp_table<R: Read>(reader: BufReader<R>) -> ProcResult<Vec<UdpNetEntry>>
 
 /// Reads the tcp socket table
 pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
-    use std::fs::File;
     let file = FileWrapper::open("/proc/net/tcp")?;
 
     read_tcp_table(BufReader::new(file))
@@ -188,7 +187,6 @@ pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
 
 /// Reads the tcp6 socket table
 pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
-    use std::fs::File;
     let file = FileWrapper::open("/proc/net/tcp6")?;
 
     read_tcp_table(BufReader::new(file))
@@ -196,7 +194,6 @@ pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
 
 /// Reads the udp socket table
 pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
-    use std::fs::File;
     let file = FileWrapper::open("/proc/net/udp")?;
 
     read_udp_table(BufReader::new(file))
@@ -204,7 +201,6 @@ pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
 
 /// Reads the udp6 socket table
 pub fn udp6() -> ProcResult<Vec<UdpNetEntry>> {
-    use std::fs::File;
     let file = FileWrapper::open("/proc/net/udp6")?;
 
     read_udp_table(BufReader::new(file))


### PR DESCRIPTION
This implements the suggestions made by @vorner in #29:

* `ProcError` variants now contain the path that caused the error
* `ProcError` implements `std::error::Error` (so it's now usable with the failure crate).  This also means it implements `Display` now.
