### PR TITLE
add vvar/vsyscall into MMapPath

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -852,6 +852,10 @@ pub enum MMapPath {
     TStack(u32),
     /// The virtual dynamically linked shared object.
     Vdso,
+    /// Shared kernel variables
+    Vvar,
+    /// obsolete virtual syscalls, succeeded by vdso
+    Vsyscall,
     /// An anonymous mapping as obtained via mmap(2).
     Anonymous,
     /// Some other pseudo-path
@@ -865,6 +869,8 @@ impl MMapPath {
             "[heap]" => MMapPath::Heap,
             "[stack]" => MMapPath::Stack,
             "[vdso]" => MMapPath::Vdso,
+            "[vvar]" => MMapPath::Vvar,
+            "[vsyscall]" => MMapPath::Vsyscall,
             x if x.starts_with("[stack:") => {
                 let mut s = x[1..x.len() - 1].split(':');
                 let tid = from_str!(u32, s.nth(1).unwrap());


### PR DESCRIPTION
`[vvar]` and `[vsyscall]` are valid `/proc/<pid>/maps` name, see

```
$ cat /proc/self/maps
55b4dda4d000-55b4dda55000 r-xp 00000000 fd:00 19660825                   /bin/cat
// snip
7f9ecea26000-7f9ecea27000 rw-p 00000000 00:00 0 
7ffc62447000-7ffc62468000 rw-p 00000000 00:00 0                          [stack]
7ffc625c8000-7ffc625cb000 r--p 00000000 00:00 0                          [vvar]
7ffc625cb000-7ffc625cd000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
```