### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["procfs", "proc", "linux", "process"]
 categories = ["os::unix-apis", "filesystem"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/src/cgroups.rs
+++ b/src/cgroups.rs
@@ -1,4 +1,4 @@
-use ProcResult;
+use crate::ProcResult;
 
 use super::Process;
 

--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -1,4 +1,4 @@
-use ProcResult;
+use crate::ProcResult;
 
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ mod platform_specific_items {
     pub const _SC_PAGESIZE: i32 = 30;
 }
 
-use platform_specific_items::*;
+use crate::platform_specific_items::*;
 
 use std::collections::HashMap;
 use std::ffi::CStr;
@@ -168,7 +168,7 @@ impl<T, R> IntoOption<T> for Result<T, R> {
 #[macro_use]
 macro_rules! expect {
     ($e:expr) => {
-        ::IntoOption::into_option($e).unwrap_or_else(|| {
+        crate::IntoOption::into_option($e).unwrap_or_else(|| {
             panic!(
                 "Failed to unwrap {}. Please report this as a procfs bug.",
                 stringify!($e)
@@ -176,7 +176,7 @@ macro_rules! expect {
         })
     };
     ($e:expr, $msg:expr) => {
-        ::IntoOption::into_option($e).unwrap_or_else(|| {
+        crate::IntoOption::into_option($e).unwrap_or_else(|| {
             panic!(
                 "Failed to unwrap {} ({}). Please report this as a procfs bug.",
                 stringify!($e),
@@ -248,22 +248,22 @@ pub(crate) fn write_value<P: AsRef<Path>, T: fmt::Display>(path: P, value: T) ->
 }
 
 mod process;
-pub use process::*;
+pub use crate::process::*;
 
 mod meminfo;
-pub use meminfo::*;
+pub use crate::meminfo::*;
 
 mod net;
-pub use net::*;
+pub use crate::net::*;
 
 mod cpuinfo;
-pub use cpuinfo::*;
+pub use crate::cpuinfo::*;
 
 mod cgroups;
-pub use cgroups::*;
+pub use crate::cgroups::*;
 
 pub mod sys;
-pub use sys::kernel::Version as KernelVersion;
+pub use crate::sys::kernel::Version as KernelVersion;
 
 lazy_static! {
     /// The boottime of the system.

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -364,7 +364,7 @@ impl Meminfo {
 #[cfg(test)]
 mod test {
     use super::*;
-    use {kernel_config, KernelVersion};
+    use crate::{kernel_config, KernelVersion};
 
     #[test]
     fn test_meminfo() {

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,4 +1,4 @@
-use ProcResult;
+use crate::ProcResult;
 
 use crate::FileWrapper;
 use byteorder::{ByteOrder, NetworkEndian};

--- a/src/sys/kernel.rs
+++ b/src/sys/kernel.rs
@@ -6,7 +6,7 @@
 use std::cmp;
 use std::str::FromStr;
 
-use {read_value, ProcResult};
+use crate::{read_value, ProcResult};
 
 /// Represents a kernel version, in major.minor.release version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/sys/vm.rs
+++ b/src/sys/vm.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::str;
 
-use {read_value, write_value, ProcResult};
+use crate::{read_value, write_value, ProcResult};
 
 /// The amount of free memory in the system that should be reserved for users with the capability cap_sys_admin.
 ///


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'