### PR TITLE
Add cast from i32 to i64 on i686

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,7 +546,7 @@ pub fn ticks_per_second() -> std::io::Result<i64> {
     if cfg!(unix) {
         match unsafe { sysconf(_SC_CLK_TCK) } {
             -1 => Err(std::io::Error::last_os_error()),
-            x => Ok(x),
+            x => Ok(x.into()),
         }
     } else {
         panic!("Not supported on non-unix platforms")
@@ -574,7 +574,7 @@ pub fn page_size() -> std::io::Result<i64> {
     if cfg!(unix) {
         match unsafe { sysconf(_SC_PAGESIZE) } {
             -1 => Err(std::io::Error::last_os_error()),
-            x => Ok(x),
+            x => Ok(x.into()),
         }
     } else {
         panic!("Not supported on non-unix platforms")


### PR DESCRIPTION
On 32bit architecture, the result of `sysconf` seems to be `i32`.
So I added cast.