### PR TITLE
Add into to fix type mismatch on i386

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,7 +597,7 @@ pub fn ticks_per_second() -> std::io::Result<i64> {
     if cfg!(unix) {
         match unsafe { sysconf(_SC_CLK_TCK) } {
             -1 => Err(std::io::Error::last_os_error()),
-            x => Ok(x),
+            x => Ok(x.into()),
         }
     } else {
         panic!("Not supported on non-unix platforms")
@@ -639,7 +639,7 @@ pub fn page_size() -> std::io::Result<i64> {
     if cfg!(unix) {
         match unsafe { sysconf(_SC_PAGESIZE) } {
             -1 => Err(std::io::Error::last_os_error()),
-            x => Ok(x),
+            x => Ok(x.into()),
         }
     } else {
         panic!("Not supported on non-unix platforms")


### PR DESCRIPTION
On 32bit environment, type mismatch occurs.

```
error[E0308]: mismatched types
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/procfs-0.7.0/src/lib.rs:600:21
    |
600 |             x => Ok(x),
    |                     ^
    |                     |
    |                     expected i64, found i32
    |                     help: you can convert an `i32` to `i64`: `x.into()`

error[E0308]: mismatched types
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/procfs-0.7.0/src/lib.rs:642:21
    |
642 |             x => Ok(x),
    |                     ^
    |                     |
    |                     expected i64, found i32
    |                     help: you can convert an `i32` to `i64`: `x.into()`
```