### PR TITLE
Clarify MSRV, and rework tests accordingly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,5 +13,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run more tests
+      run: cargo test -p --manifest-path procfs-tests/Cargo.toml -p procfs-tests
     - name: Build docs
       run: cargo doc --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: required
 dist: xenial
 rust:
-  - 1.33.0
+  - 1.38.0
   - stable
   - beta
   - nightly
@@ -10,4 +10,14 @@ script:
   - cargo build --verbose --all --all-features
   - env RUST_BACKTRACE=1 cargo test --verbose --all --all-features
   - env RUST_BACKTRACE=1 cargo test --verbose --all --no-default-features
+  - env RUST_BACKTRACE=1 cargo test -p --manifest-path procfs-tests/Cargo.toml -p procfs-tests
   - cargo doc --all-features
+
+jobs:
+  include:
+    rust: 1.33.0
+    script: 
+        - cargo build --verbose --all
+        - env RUST_BACKTRACE=1 cargo test --verbose --all
+        - cargo doc
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ libflate = "1"
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
-failure = "0.1.5"
 procinfo = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ The following cargo features are available:
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of 1.33.0 (2019-02-28)
+This crate requires a minimum rust version of 1.33.0 (2019-02-28), though if you use the optional `backtrace` feature,
+rust 1.38.0 is required (2019-09-23).
 
 ## License
 

--- a/procfs-tests/.gitignore
+++ b/procfs-tests/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/procfs-tests/Cargo.toml
+++ b/procfs-tests/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "procfs-tests"
+version = "0.1.0"
+authors = ["Andrew Chin <achin@eminence32.net>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+procfs = {path = ".."}
+
+[dev-dependencies]
+failure = "0.1"

--- a/procfs-tests/README.md
+++ b/procfs-tests/README.md
@@ -1,0 +1,4 @@
+This subcrate contains tests that require a newer rust than our MSRV. 
+By putting them in their own sub-crate, we can more easily test them selectively.
+
+In particular, tests that involve the "backtrace" feature/crate require rust 1.38.

--- a/procfs-tests/src/lib.rs
+++ b/procfs-tests/src/lib.rs
@@ -1,0 +1,25 @@
+
+
+#[cfg(test)]
+mod tests {
+    extern crate failure;
+        /// Test that our error type can be easily used with the `failure` crate
+        #[test]
+        fn test_failure() {
+            fn inner() -> Result<(), failure::Error> {
+                let _load = procfs::LoadAverage::new()?;
+                Ok(())
+            }
+            let _ = inner();
+    
+            fn inner2() -> Result<(), failure::Error> {
+                let proc = procfs::process::Process::new(1)?;
+                let _io = proc.maps()?;
+                Ok(())
+            }
+    
+            let _ = inner2();
+            // Unwrapping this failure should produce a message that looks like:
+            // thread 'tests::test_failure' panicked at 'called `Result::unwrap()` on an `Err` value: PermissionDenied(Some("/proc/1/maps"))', src/libcore/result.rs:997:5
+        }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,7 +1002,6 @@ pub fn modules() -> ProcResult<HashMap<String, KernelModule>> {
 
 #[cfg(test)]
 mod tests {
-    extern crate failure;
     use super::process::Process;
     use super::*;
 
@@ -1110,26 +1109,6 @@ mod tests {
             }
             x => panic!("Unexpected return value: {:?}", x),
         }
-    }
-
-    /// Test that our error type can be easily used with the `failure` crate
-    #[test]
-    fn test_failure() {
-        fn inner() -> Result<(), failure::Error> {
-            let _load = LoadAverage::new()?;
-            Ok(())
-        }
-        let _ = inner();
-
-        fn inner2() -> Result<(), failure::Error> {
-            let proc = Process::new(1)?;
-            let _io = proc.maps()?;
-            Ok(())
-        }
-
-        let _ = inner2();
-        // Unwrapping this failure should produce a message that looks like:
-        // thread 'tests::test_failure' panicked at 'called `Result::unwrap()` on an `Err` value: PermissionDenied(Some("/proc/1/maps"))', src/libcore/result.rs:997:5
     }
 
     #[test]


### PR DESCRIPTION
The backtrace crate/feature now requires 1.38.0, but there's not a great
way to conditionally run tests based on rust version.  So the tests that
require 1.38.0 are extracted into their own subcrate, which is not tested
when testing with 1.33.0