### PR TITLE
Add an process hierarchy example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ Prints out details about the current process (the dumper itself), or a process s
 
 Runs continually and prints out how many bytes/packets are sent/received.  Press ctrl-c to exit the example:
 
-```
+```text
        Interface: bytes recv                         bytes sent
 ================  ====================               ====================
  br-883c4c992deb: 823307769                0.2 kbps  1537694158               0.5 kbps
@@ -35,7 +35,7 @@ Runs continually and prints out how many bytes/packets are sent/received.  Press
 Prints out all open and listening TCP/UDP sockets, along with the owning process.  The
 output format is very similar to the standard `netstat` linux utility:
 
-```
+```text
 Local address              Remote address             State           Inode    PID/Program name
 0.0.0.0:53                 0.0.0.0:0                  Listen          30883        1409/pdns_server
 0.0.0.0:51413              0.0.0.0:0                  Listen          24263        927/transmission-da
@@ -53,7 +53,7 @@ Prints out CPU/IO/Memory pressure information
 Prints out all processes that share the same tty as the current terminal.  This is very similar to the standard
 `ps` utility on linux when run with no arguments:
 
-```
+```text
   PID TTY          TIME CMD
  8369 pty/13       4.05 bash
 23124 pty/13       0.23 basic-http-serv
@@ -64,7 +64,7 @@ Prints out all processes that share the same tty as the current terminal.  This 
 
 Shows several ways to get the current memory usage of the current process
 
-```
+```text
 PID: 21867
 Memory page size: 4096
 == Data from /proc/self/stat:
@@ -90,7 +90,7 @@ This lists all the loaded kernel modules, in a simple tree format.
 
 Lists IO information for local disks:
 
-```
+```text
 sda1 mounted on /:
   total reads: 7325390 (13640070 ms)
   total writes: 124191552 (119109541 ms)
@@ -108,7 +108,7 @@ Shows current file locks in a format that is similiar to the `lslocks` utility.
 
 Lists all mountpoints, along with their type and options:
 
-```
+```text
 sysfs on /sys type sysfs (noexec,relatime,nodev,rw,nosuid)
 proc on /proc type proc (noexec,rw,nodev,relatime,nosuid)
 udev on /dev type devtmpfs (rw,nosuid,relatime)
@@ -125,3 +125,20 @@ tmpfs on /run type tmpfs (rw,nosuid,noexec,relatime)
 /dev/sda1 on / type ext4 (rw,relatime)
   errors = remount-ro
 ```
+
+## process_hierarchy.rs
+
+Lists all processes as a tree. Sub-processes will be hierarchically ordered beneath their parents.
+
+```text
+1       /usr/lib/systemd/systemd --system --deserialize 54
+366         /usr/lib/systemd/systemd-journald
+375         /usr/lib/systemd/systemd-udevd
+383         /usr/bin/lvmetad -f
+525         /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+529         /usr/bin/syncthing -no-browser -no-restart -logflags=0
+608             /usr/bin/syncthing -no-browser -no-restart -logflags=0
+530         /usr/lib/systemd/systemd-logind
+...
+```
+

--- a/examples/process_hierarchy.rs
+++ b/examples/process_hierarchy.rs
@@ -1,0 +1,63 @@
+use procfs::process::{all_processes, Process};
+
+
+/// Print all processes as a tree.
+/// The tree reflects the hierarchical relationship between parent and child processes.
+fn main() {
+    // Get all processes
+    let processes = match all_processes() {
+        Err(err) => {
+            println!("Failed to read all processes: {}", err);
+            return;
+        }
+        Ok(processes) => processes,
+    };
+
+    // Iterate through all processes and start with top-level processes.
+    // Those can be identified by checking if their parent PID is zero.
+    for process in &processes {
+        if process.stat.ppid == 0 {
+            print_process(&process, &processes, 0);
+        }
+    }
+}
+
+/// Take a process, print its command and recursively list all child processes.
+/// This function will call itself until no further children can be found.
+/// It's a depth-first tree exploration.
+///
+/// depth: The hierarchical depth of the process
+fn print_process(process: &Process, all_processes: &Vec<Process>, depth: usize) {
+    let cmdline = match process.cmdline() {
+        Ok(cmdline) => cmdline.join(" "),
+        Err(_) => "zombie process".into(),
+    };
+
+    // Some processes seem to have an empty cmdline.
+    if cmdline.is_empty() {
+        return;
+    }
+
+    // 10 characters width for the pid
+    let pid_length = 8;
+    let mut pid = process.pid.to_string();
+    pid.push_str(&" ".repeat(pid_length - pid.len()));
+
+    let padding = " ".repeat(4 * depth);
+    println!("{}{}{}", pid, padding, cmdline);
+
+    let children = get_children(process.pid, all_processes);
+    for child in &children {
+        print_process(child, &all_processes, depth + 1);
+    }
+}
+
+
+/// Get all children of a specific process, by iterating through all processes and
+/// checking their parent pid.
+pub fn get_children(pid: i32, all_processes: &Vec<Process>) -> Vec<&Process> {
+    all_processes
+        .into_iter()
+        .filter(|process| process.stat.ppid == pid)
+        .collect()
+}


### PR DESCRIPTION
Hey :)

Here is an example for working with child processes.

I thought it would be a cool idea to visualize the current process list as a tree.
It's very basic and there's no fancy styling, but people should get an idea on how to work with children.

There's one thing I couldn't figure out, though.


There seem to be many processes in `/proc` with an empty cmdline.
However, they still seem to be alive. Do you know something about those?

```
    // Some processes seem to have an empty cmdline.
    if cmdline.is_empty() {
        return;
    }
```

When running the example without this check, a lot of such processes are listed.

Resolves #78 