### PR TITLE
adds pid_max

### DIFF
--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -119,6 +119,27 @@ impl cmp::PartialOrd for Version {
     }
 }
 
+/// Returns the maximum process ID number.
+///
+/// This is taken from `/proc/sys/kernel/pid_max`.
+///
+/// # Example
+///
+/// ```
+/// let pid_max = procfs::sys::kernel::pid_max().unwrap();
+///
+/// let pid = 42; // e.g. from user input, CLI args, etc.
+///
+/// if pid > pid_max {
+///     eprintln!("bad process ID: {}", pid)
+/// } else {
+///     println!("good process ID: {}", pid);
+/// }
+/// ```
+pub fn pid_max() -> ProcResult<i32> {
+    read_value("/proc/sys/kernel/pid_max")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +162,10 @@ mod tests {
     #[test]
     fn test_current() {
         let _ = Version::current().unwrap();
+    }
+
+    #[test]
+    fn test_pid_max() {
+        assert!(pid_max().is_ok());
     }
 }

--- a/support.md
+++ b/support.md
@@ -180,7 +180,7 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
 	* [ ] `/proc/sys/kernel/overflowuid`
 	* [ ] `/proc/sys/kernel/panic`
 	* [ ] `/proc/sys/kernel/panic_on_oops`
-	* [ ] `/proc/sys/kernel/pid_max`
+	* [x] `/proc/sys/kernel/pid_max`
 	* [ ] `/proc/sys/kernel/powersave-nap`
 	* [ ] `/proc/sys/kernel/printk`
 	* [ ] `/proc/sys/kernel/pty`


### PR DESCRIPTION
This should be pretty self-explanatory, available since 2.5.34. Don't know if that requires checking, but I guess not.

Let me know if I should add a `pub use` in any of `lib.rs` or `sys/mod.rs`, not sure if that's needed/wanted.

---

I recently needed this for checking user input of a CLI tool that uses PIDs as arguments, see example in the docs.