### PR TITLE
Add a method to get a task for main thread

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -888,6 +888,11 @@ impl Process {
         StatM::from_reader(file)
     }
 
+    /// Return a task for the main thread of this process
+    pub fn task_main_thread(&self) -> ProcResult<Task> {
+        Task::from_rel_path(self.pid, Path::new(&format!("{}", self.pid)))
+    }
+
     /// Iterate over all the [`Task`]s (aka Threads) in this process
     ///
     /// Note that the iterator does not receive a snapshot of tasks, it is a

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -16,6 +16,13 @@ fn check_unwrap<T>(prc: &Process, val: ProcResult<T>) {
     }
 }
 
+#[test]
+fn test_main_thread_task() {
+    let myself = Process::myself().unwrap();
+    let task = myself.task_main_thread().unwrap();
+    check_unwrap(&myself, task.stat());
+}
+
 #[allow(clippy::cognitive_complexity)]
 #[test]
 fn test_self_proc() {


### PR DESCRIPTION
While this method is not strictly required (we can always get the main task by filtering `TasksIter` as `process.tasks().filter(...)`), I think it improves the API ergonomics for cases when we care about the main thread only and makes it more simple because the main task ID is always equal to the process ID.