### PR TITLE
Add github action workflow check that enforces 'cargo fmt'

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,9 @@ jobs:
       if: matrix.toolchain == '1.33.0'
       run: cargo +${{ matrix.toolchain }} doc
 
+    - name: Run cargo fmt
+      if: matrix.toolchain == 'stable'
+      run: cargo +${{ matrix.toolchain }} fmt -- --check
 
   android-check:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,12 @@
 name: Rust
 
-on: [push]
-
-
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
+  pull_request:
 
 jobs:
   build:

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -58,10 +58,10 @@ use crate::from_iter;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read};
-#[cfg(all(unix, not(target_os = "android")))]
-use std::os::linux::fs::MetadataExt;
 #[cfg(target_os = "android")]
 use std::os::android::fs::MetadataExt;
+#[cfg(all(unix, not(target_os = "android")))]
+use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 


### PR DESCRIPTION
Hey there :)

This PR adds a `cargo fmt` check to the `rust` Github action.
That should enforce/remind people to use `cargo fmt` in their PRs.

I'm also thinking about adding another PR, which resolves all open `cargo clippy` issues and adds a cargo clippy check to the action. If you don't mind, I'll start working on that as well momentarily.

This also adds a rule, which actually runs the checks on PRs.