### PR TITLE
Fix clippy and rustfmt issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // Don't throw clippy warnings for manual string stripping.
 // The suggested fix with `strip_prefix` removes support for Rust 1.33 and 1.38
+#![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::manual_strip)]
 // Don't throw rustc lint warnings for the deprecated name `intra_doc_link_resolution_failure`.
 // The suggested rename to `broken_intra_doc_links` removes support for Rust 1.33 and 1.38.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+// Don't throw clippy warnings for manual string stripping.
+// The suggested fix with `strip_prefix` removes support for Rust 1.33 and 1.38
+#![allow(clippy::manual_strip)]
+// Don't throw rustc lint warnings for the deprecated name `intra_doc_link_resolution_failure`.
+// The suggested rename to `broken_intra_doc_links` removes support for Rust 1.33 and 1.38.
+#![allow(renamed_and_removed_lints)]
 #![deny(intra_doc_link_resolution_failure)]
 //! This crate provides to an interface into the linux `procfs` filesystem, usually mounted at
 //! `/proc`.

--- a/src/net.rs
+++ b/src/net.rs
@@ -459,17 +459,18 @@ pub fn arp() -> ProcResult<Vec<ARPEntry>> {
 
     let mut vec = Vec::new();
 
-    // first line is a header we need to skip
+    // First line is a header we need to skip
     for line in reader.lines().skip(1) {
+        // Check if there might have been an IO error.
         let line = line?;
-        let mut s = line.split_whitespace();
-        let ip_address = expect!(Ipv4Addr::from_str(expect!(s.next())));
-        let hw = from_str!(u32, &expect!(s.next())[2..], 16);
+        let mut line = line.split_whitespace();
+        let ip_address = expect!(Ipv4Addr::from_str(expect!(line.next())));
+        let hw = from_str!(u32, &expect!(line.next())[2..], 16);
         let hw = ARPHardware::from_bits_truncate(hw);
-        let flags = from_str!(u32, &expect!(s.next())[2..], 16);
+        let flags = from_str!(u32, &expect!(line.next())[2..], 16);
         let flags = ARPFlags::from_bits_truncate(flags);
 
-        let mac = expect!(s.next());
+        let mac = expect!(line.next());
         let mut mac: Vec<Result<u8, _>> =
             mac.split(':').map(|s| Ok(from_str!(u8, s, 16))).collect();
 
@@ -490,13 +491,13 @@ pub fn arp() -> ProcResult<Vec<ARPEntry>> {
         };
 
         // mask is always "*"
-        let _mask = expect!(s.next());
-        let dev = expect!(s.next());
+        let _mask = expect!(line.next());
+        let dev = expect!(line.next());
 
         vec.push(ARPEntry {
             ip_address,
             hw_type: hw,
-            flags: flags,
+            flags,
             hw_address: mac,
             device: dev.to_string(),
         })

--- a/src/net.rs
+++ b/src/net.rs
@@ -475,16 +475,29 @@ pub fn arp() -> ProcResult<Vec<ARPEntry>> {
             mac.split(':').map(|s| Ok(from_str!(u8, s, 16))).collect();
 
         let mac = if mac.len() == 6 {
-            let f = mac.pop().unwrap()?;
-            let e = mac.pop().unwrap()?;
-            let d = mac.pop().unwrap()?;
-            let c = mac.pop().unwrap()?;
-            let b = mac.pop().unwrap()?;
-            let a = mac.pop().unwrap()?;
-            if a == 0 && b == 0 && c == 0 && d == 0 && e == 0 && f == 0 {
+            let mac_block_f = mac.pop().unwrap()?;
+            let mac_block_e = mac.pop().unwrap()?;
+            let mac_block_d = mac.pop().unwrap()?;
+            let mac_block_c = mac.pop().unwrap()?;
+            let mac_block_b = mac.pop().unwrap()?;
+            let mac_block_a = mac.pop().unwrap()?;
+            if mac_block_a == 0
+                && mac_block_b == 0
+                && mac_block_c == 0
+                && mac_block_d == 0
+                && mac_block_e == 0
+                && mac_block_f == 0
+            {
                 None
             } else {
-                Some([a, b, c, d, e, f])
+                Some([
+                    mac_block_a,
+                    mac_block_b,
+                    mac_block_c,
+                    mac_block_d,
+                    mac_block_e,
+                    mac_block_f,
+                ])
             }
         } else {
             None

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,3 +1,7 @@
+// Don't throw clippy warnings for manual string stripping.
+// The suggested fix with `strip_prefix` removes support for Rust 1.33 and 1.38
+#![allow(clippy::manual_strip)]
+
 //! Information about the networking layer.
 //!
 //! This module corresponds to the `/proc/net` directory and contains various information about the

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,5 +1,6 @@
 // Don't throw clippy warnings for manual string stripping.
 // The suggested fix with `strip_prefix` removes support for Rust 1.33 and 1.38
+#![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::manual_strip)]
 
 //! Information about the networking layer.

--- a/src/net.rs
+++ b/src/net.rs
@@ -233,13 +233,13 @@ fn parse_addressport_str(s: &str) -> ProcResult<SocketAddr> {
 
         let ip = Ipv6Addr::new(
             ((ip_a >> 16) & 0xffff) as u16,
-            ((ip_a >> 0) & 0xffff) as u16,
+            (ip_a & 0xffff) as u16,
             ((ip_b >> 16) & 0xffff) as u16,
-            ((ip_b >> 0) & 0xffff) as u16,
+            (ip_b & 0xffff) as u16,
             ((ip_c >> 16) & 0xffff) as u16,
-            ((ip_c >> 0) & 0xffff) as u16,
+            (ip_c & 0xffff) as u16,
             ((ip_d >> 16) & 0xffff) as u16,
-            ((ip_d >> 0) & 0xffff) as u16,
+            (ip_d & 0xffff) as u16,
         );
 
         Ok(SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0)))

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -58,10 +58,10 @@ use crate::from_iter;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Read};
-#[cfg(all(unix, not(target_os = "android")))]
-use std::os::linux::fs::MetadataExt;
 #[cfg(target_os = "android")]
 use std::os::android::fs::MetadataExt;
+#[cfg(all(unix, not(target_os = "android")))]
+use std::os::linux::fs::MetadataExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 


### PR DESCRIPTION
I just took the opportunity and started to hack around a little :)

This PR is build upon the other `cargo fmt` branch.

This probably needs some discussion as mentioned in issue #69.
There are two `strip_prefix` commits, which replace manual string prefix removal by the newly added `strip_prefix` method and one commit which renames the deprecated `intra_doc_link_resolution_failure`.

Since the latest feature has only just been added in Rust `1.45`, this will drop support for rust `1.38` and `1.33`.
I'm not sure what your policy for support of old rust versions is. In case you don't want to drop support for these versions, I would disable all clippy rules for all breaking changes and reintroduce these targets to the CI rules.

Anyway, I hope you would like to see clippy being added to this project's CI