### PR TITLE
Swap libflate for flate2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: ["1.33.0", "1.38.0", "stable", "beta", "nightly"]
+        toolchain: ["1.34.0", "1.38.0", "stable", "beta", "nightly"]
     runs-on: ubuntu-latest
 
     steps:
@@ -25,15 +25,15 @@ jobs:
       run: cargo +${{ matrix.toolchain }} test --verbose
 
     - name: Run more tests
-      if: matrix.toolchain != '1.33.0'
+      if: matrix.toolchain != '1.34.0'
       run: cargo +${{ matrix.toolchain }} test -p --manifest-path procfs-tests/Cargo.toml -p procfs-tests
 
     - name: Build docs (all features)
-      if: matrix.toolchain != '1.33.0'
+      if: matrix.toolchain != '1.34.0'
       run: cargo +${{ matrix.toolchain }} doc --all-features
 
     - name: Build docs
-      if: matrix.toolchain == '1.33.0'
+      if: matrix.toolchain == '1.34.0'
       run: cargo +${{ matrix.toolchain }} doc
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1"
 chrono = {version = "0.4", optional = true }
 byteorder = {version="1", features=["i128"]}
 hex = "0.4"
-libflate = "1"
+flate2 = "1"
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ procfs
 
 [![Crate](https://img.shields.io/crates/v/procfs.svg)](https://crates.io/crates/procfs)
 [![Docs](https://docs.rs/procfs/badge.svg)](https://docs.rs/procfs)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.33+-lightgray.svg)](https://github.com/eminence/procfs#minimum-rust-version)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.34+-lightgray.svg)](https://github.com/eminence/procfs#minimum-rust-version)
 
 
 This crate is an interface to the `proc` pseudo-filesystem on linux, which is normally mounted as `/proc`.
@@ -71,7 +71,7 @@ The following cargo features are available:
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of 1.33.0 (2019-02-28), though if you use the optional `backtrace` feature,
+This crate requires a minimum rust version of 1.34.0 (2019-04-11), though if you use the optional `backtrace` feature,
 rust 1.38.0 is required (2019-09-23).
 
 ## License

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -4,6 +4,7 @@
 //!
 //! Additional functions can be found in the [kernel::keys](crate::sys::kernel::keys) module.
 use crate::{FileWrapper, ProcResult};
+use bitflags::bitflags;
 use std::{
     collections::HashMap,
     io::{BufRead, BufReader},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,17 +42,8 @@
 //! [examples](https://github.com/eminence/procfs/tree/master/examples) folder of the code repository.
 //!
 
-#[cfg(unix)]
-extern crate libc;
-#[macro_use]
-extern crate bitflags;
-
-#[macro_use]
-extern crate lazy_static;
-extern crate byteorder;
-extern crate hex;
-extern crate libflate;
-
+use bitflags::bitflags;
+use lazy_static::lazy_static;
 use libc::pid_t;
 use libc::sysconf;
 use libc::{_SC_CLK_TCK, _SC_PAGESIZE};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,11 +672,11 @@ pub enum ConfigSetting {
 /// If CONFIG_KCONFIG_PROC is available, the config is read from `/proc/config.gz`.
 /// Else look in `/boot/config-$(uname -r)` or `/boot/config` (in that order).
 pub fn kernel_config() -> ProcResult<HashMap<String, ConfigSetting>> {
-    use libflate::gzip::Decoder;
+    use flate2::read::GzDecoder;
 
     let reader: Box<dyn BufRead> = if Path::new(PROC_CONFIG_GZ).exists() {
         let file = FileWrapper::open(PROC_CONFIG_GZ)?;
-        let decoder = Decoder::new(file)?;
+        let decoder = GzDecoder::new(file);
         Box::new(BufReader::new(decoder))
     } else {
         let mut kernel: libc::utsname = unsafe { mem::zeroed() };

--- a/src/net.rs
+++ b/src/net.rs
@@ -49,6 +49,7 @@ use crate::ProcResult;
 use std::collections::HashMap;
 
 use crate::FileWrapper;
+use bitflags::bitflags;
 use byteorder::{ByteOrder, NativeEndian, NetworkEndian};
 use std::io::{BufRead, BufReader, Read};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/src/process/mount.rs
+++ b/src/process/mount.rs
@@ -1,3 +1,5 @@
+use bitflags::bitflags;
+
 use crate::{from_iter, FileWrapper, ProcResult};
 
 use std::collections::HashMap;


### PR DESCRIPTION
flate2 has proven to be the more popular implementation of the DEFLATE
algorithm in Rust. Standardizing on the more popular variant means
downstream crates don't end up with two separate libraries implementing
the DEFLATE algorithm in their crate graph.

flate2 also avoids depending upon the adler32 crate, which uses the
nonstandard Zlib license. Instead it uses the adler crate, which is
licensed under the more common MIT/Apache 2 licenses.

----

@eminence hope this isn't too much to ask. I noticed that test_kernel_config doesn't run in CI, so I manually tested this change on a Gentoo box that had /proc/config.gz, and all was well!