### PR TITLE
Add a private field to some large structs

### DIFF
--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -22,9 +22,15 @@ use super::{convert_to_kibibytes, FileWrapper, ProcResult};
 /// This imprecision in /proc/meminfo is known,
 /// but is not corrected due to legacy concerns -
 /// programs rely on /proc/meminfo to specify size with the "kB" string.
+///
+/// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug)]
 #[allow(non_snake_case)]
 pub struct Meminfo {
+    // this private field prevents clients from directly constructing this object.
+    // this allows us (procfs) to add fields in a semver compatible way
+    _private: (),
+
     /// Total usable RAM (i.e., physical RAM minus a few reserved bits and the kernel binary code).
     pub mem_total: u64,
     /// The sum of [LowFree](#structfield.low_free) + [HighFree](#structfield.high_free).
@@ -302,6 +308,7 @@ impl Meminfo {
         // if there's anything still left in the map at the end, that
         // means we probably have a bug/typo, or are out-of-date
         let meminfo = Meminfo {
+            _private: (),
             mem_total: expect!(map.remove("MemTotal")),
             mem_free: expect!(map.remove("MemFree")),
             mem_available: map.remove("MemAvailable"),

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -23,8 +23,12 @@ macro_rules! since_kernel {
 /// To construct one of these structures, you have to first create a [Process](crate::process::Process).
 ///
 /// Not all fields are available in every kernel.  These fields have `Option<T>` types.
+///
+/// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug, Clone)]
 pub struct Stat {
+    _private: (),
+
     /// The process ID.
     pub pid: i32,
     /// The filename of the executable, in parentheses.
@@ -309,6 +313,7 @@ impl Stat {
         let exit_code = since_kernel!(3, 5, 0, expect!(from_iter(&mut rest)));
 
         Ok(Stat {
+            _private: (),
             pid,
             comm,
             state,

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -11,8 +11,11 @@ use std::io::{BufRead, BufReader, Read};
 /// isn't totally reliable, since some kernels might backport certain fields, or fields might
 /// only be present if certain kernel configuration options are enabled.  Be prepared to
 /// handle `None` values.
+///
+/// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug, Clone)]
 pub struct Status {
+    _private: (),
     /// Command run by this process.
     pub name: String,
     /// Process umask, expressed in octal with a leading zero; see umask(2).  (Since Linux 4.7.)
@@ -189,6 +192,7 @@ impl Status {
         }
 
         let status = Status {
+            _private: (),
             name: expect!(map.remove("Name")),
             umask: map
                 .remove("Umask")


### PR DESCRIPTION
Adding a private field to these structs will prevent clients from
directly constructing them.  This will allow us to add new fields
to them in a semver compatible way.

This change itself is a semver incompatible change, though.  CC #69 