### PR TITLE
Introduce fd_count() in addition to fd()

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -743,6 +743,13 @@ impl Process {
         Ok(vec)
     }
 
+    /// Gets the number of open file descriptors for a process
+    pub fn fd_count(&self) -> ProcResult<usize> {
+        let path = self.root.join("fd");
+
+        Ok(wrap_io_error!(path, path.read_dir())?.count())
+    }
+
     /// Gets a list of open file descriptors for a process
     pub fn fd(&self) -> ProcResult<Vec<FDInfo>> {
         use std::ffi::OsStr;


### PR DESCRIPTION
Prometheus crate uses `fd()` to return the number of open file descriptors. Currently it takes 500ms to count 80k open files in an uncontended case, with this method we can cut this down to just 100ms by not resolving details of every open file descriptor.

See: https://github.com/tikv/rust-prometheus/blob/512e8ed44c0fbbcef/src/process_collector.rs#L134-L137