### PR TITLE
Fix build

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -934,7 +934,7 @@ impl Process {
                         })?;
 
                         // This ignores the case when our Key: Value pairs are really Key Value pairs. Is this a good idea?
-                        let k = if let Some(k) = k.strip_suffix(":") { k } else { k };
+                        let k = k.trim_end_matches(":");
 
                         current_data.map.insert(k.into(), v * size_multiplier);
                     }


### PR DESCRIPTION
strip_suffix was introduced in 1.45 while our MSRV is 1.34

-------

Sorry for that, not yet used to working with older compiler versions. Maybe it would be a good idea to run your checks on PRs as well so that using features that are too new will fail early?