### PR TITLE
Override default cpuinfo source

### DIFF
--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -18,7 +18,8 @@ pub struct CpuInfo {
 }
 
 impl CpuInfo {
-    fn from_reader<R: Read>(r: R) -> ProcResult<CpuInfo> {
+    /// Get CpuInfo from a custom Read instead of the default `/proc/cpuinfo`.
+    pub fn from_reader<R: Read>(r: R) -> ProcResult<CpuInfo> {
         use std::io::{BufRead, BufReader};
 
         let reader = BufReader::new(r);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -956,8 +956,8 @@ impl KernelStats {
     pub fn new() -> ProcResult<KernelStats> {
         KernelStats::from_reader(FileWrapper::open("/proc/stat")?)
     }
-
-    fn from_reader<R: io::Read>(r: R) -> ProcResult<KernelStats> {
+    /// Get KernelStatus from a custom Read instead of the default `/proc/stat`.
+    pub fn from_reader<R: io::Read>(r: R) -> ProcResult<KernelStats> {
         let bufread = BufReader::new(r);
         let lines = bufread.lines();
 

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -286,7 +286,8 @@ impl Meminfo {
         Meminfo::from_reader(f)
     }
 
-    fn from_reader<R: io::Read>(r: R) -> ProcResult<Meminfo> {
+    /// Get Meminfo from a custom Read instead of the default `/proc/meminfo`.
+    pub fn from_reader<R: io::Read>(r: R) -> ProcResult<Meminfo> {
         use std::collections::HashMap;
         use std::io::{BufRead, BufReader};
 


### PR DESCRIPTION
Overriding the source of cpuinfo information can help in some situations. For example, parsing a file that comes from another system.