### PR TITLE
Create `FDInfo` from raw fd and pid

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -690,7 +690,7 @@ impl FDInfo {
     pub fn from_raw_fd_with_root(root: impl AsRef<Path>, pid: pid_t, raw_fd: i32) -> ProcResult<Self> {
         let path = root.as_ref().join(pid.to_string()).join("fd").join(raw_fd.to_string());
         let link = wrap_io_error!(path, read_link(&path))?;
-        let md = wrap_io_error!(path, path.metadata())?;
+        let md = wrap_io_error!(path, path.symlink_metadata())?;
         let link_os: &OsStr = link.as_ref();
         Ok(Self {
             fd: raw_fd as u32,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -683,10 +683,12 @@ pub struct FDInfo {
 impl FDInfo {
     /// Gets a file descriptor from a raw fd
     pub fn from_raw_fd(pid: pid_t, raw_fd: i32) -> ProcResult<Self> {
-        let path = PathBuf::from("/proc")
-            .join(pid.to_string())
-            .join("fd")
-            .join(raw_fd.to_string());
+        Self::from_raw_fd_with_root("/proc", pid, raw_fd)
+    }
+
+    /// Gets a file descriptor from a raw fd based on a specified `/proc` path
+    pub fn from_raw_fd_with_root(root: impl AsRef<Path>, pid: pid_t, raw_fd: i32) -> ProcResult<Self> {
+        let path = root.as_ref().join(pid.to_string()).join("fd").join(raw_fd.to_string());
         let link = wrap_io_error!(path, read_link(&path))?;
         let md = wrap_io_error!(path, path.metadata())?;
         let link_os: &OsStr = link.as_ref();

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -55,8 +55,10 @@
 use super::*;
 use crate::from_iter;
 
+use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
+use std::fs::read_link;
 use std::io::{self, Read};
 #[cfg(target_os = "android")]
 use std::os::android::fs::MetadataExt;
@@ -679,6 +681,22 @@ pub struct FDInfo {
 }
 
 impl FDInfo {
+    /// Gets a file descriptor from a raw fd
+    pub fn from_raw_fd(pid: pid_t, raw_fd: i32) -> ProcResult<Self> {
+        let path = PathBuf::from("/proc")
+            .join(pid.to_string())
+            .join("fd")
+            .join(raw_fd.to_string());
+        let link = wrap_io_error!(path, read_link(&path))?;
+        let md = wrap_io_error!(path, path.metadata())?;
+        let link_os: &OsStr = link.as_ref();
+        Ok(Self {
+            fd: raw_fd as u32,
+            mode: (md.st_mode() as libc::mode_t) & libc::S_IRWXU,
+            target: expect!(FDTarget::from_str(expect!(link_os.to_str()))),
+        })
+    }
+
     /// Gets the read/write mode of this file descriptor as a bitfield
     pub fn mode(&self) -> FDPermissions {
         FDPermissions::from_bits_truncate(self.mode)
@@ -814,7 +832,6 @@ impl Process {
     /// Gets the current environment for the process.  This is done by reading the
     /// `/proc/pid/environ` file.
     pub fn environ(&self) -> ProcResult<HashMap<OsString, OsString>> {
-        use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
         let mut map = HashMap::new();
@@ -954,9 +971,6 @@ impl Process {
 
     /// Gets a list of open file descriptors for a process
     pub fn fd(&self) -> ProcResult<Vec<FDInfo>> {
-        use std::ffi::OsStr;
-        use std::fs::read_link;
-
         let mut vec = Vec::new();
 
         let path = self.root.join("fd");

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -267,11 +267,19 @@ fn test_mmap_path() {
     );
 }
 #[test]
-fn test_proc_fd() {
+fn test_proc_fds() {
     let myself = Process::myself().unwrap();
     for fd in myself.fd().unwrap() {
         println!("{:?} {:?}", fd, fd.mode());
     }
+}
+
+#[test]
+fn test_proc_fd() {
+    let myself = Process::myself().unwrap();
+    let raw_fd = myself.fd().unwrap().get(0).unwrap().fd as i32;
+    let fd = FDInfo::from_raw_fd(myself.pid, raw_fd).unwrap();
+    println!("{:?} {:?}", fd, fd.mode());
 }
 
 #[test]


### PR DESCRIPTION
Sometimes it's needed for working with single high level `FDInfo` not raw fd, but getting all fds from `Process` is not suitable.