### PR TITLE
Change Process to use directory fd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ byteorder = {version="1", features=["i128"]}
 hex = "0.4"
 flate2 = "1"
 backtrace = { version = "0.3", optional = true }
+nix = "0.20"
 
 [dev-dependencies]
 procinfo = "0.4.2"

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -11,6 +11,7 @@ fn main() {
     };
     println!("{:#?}", prc);
 
-    println!("State: {:?}", prc.stat.state());
-    println!("RSS:   {} bytes", prc.stat.rss_bytes());
+    let stat = prc.stat().unwrap();
+    println!("State: {:?}", stat.state());
+    println!("RSS:   {} bytes", stat.rss_bytes());
 }

--- a/examples/lslocks.rs
+++ b/examples/lslocks.rs
@@ -33,7 +33,8 @@ fn main() {
         let mut found = false;
         if let Some(pid) = lock.pid {
             if let Ok(fds) = Process::new(pid).and_then(|p| p.fd()) {
-                for fd in fds {
+                for f in fds {
+                    let fd = f.unwrap();
                     if let FDTarget::Path(p) = fd.target {
                         let cstr = CString::new(p.as_os_str().as_bytes()).unwrap();
 

--- a/examples/process_hierarchy.rs
+++ b/examples/process_hierarchy.rs
@@ -1,17 +1,25 @@
-use procfs::process::{all_processes, Process};
+use procfs::process::{all_processes, Stat};
 
 /// Print all processes as a tree.
 /// The tree reflects the hierarchical relationship between parent and child processes.
+struct ProcessEntry {
+    stat: Stat,
+    cmdline: Option<Vec<String>>
+}
+
 fn main() {
     // Get all processes
-    let processes = match all_processes() {
+    let processes: Vec<ProcessEntry> = match all_processes() {
         Err(err) => {
             println!("Failed to read all processes: {}", err);
             return;
         }
         Ok(processes) => processes,
-    };
-
+    }.filter_map(|v| v.and_then(|p| {
+        let stat = p.stat()?;
+        let cmdline = p.cmdline().ok();
+        Ok(ProcessEntry { stat, cmdline })
+    }).ok()).collect();
     // Iterate through all processes and start with top-level processes.
     // Those can be identified by checking if their parent PID is zero.
     for process in &processes {
@@ -26,10 +34,10 @@ fn main() {
 /// It's a depth-first tree exploration.
 ///
 /// depth: The hierarchical depth of the process
-fn print_process(process: &Process, all_processes: &Vec<Process>, depth: usize) {
-    let cmdline = match process.cmdline() {
-        Ok(cmdline) => cmdline.join(" "),
-        Err(_) => "zombie process".into(),
+fn print_process(process: &ProcessEntry, all_processes: &Vec<ProcessEntry>, depth: usize) {
+    let cmdline = match &process.cmdline {
+        Some(cmdline) => cmdline.join(" "),
+        None => "zombie process".into(),
     };
 
     // Some processes seem to have an empty cmdline.
@@ -39,13 +47,13 @@ fn print_process(process: &Process, all_processes: &Vec<Process>, depth: usize) 
 
     // 10 characters width for the pid
     let pid_length = 8;
-    let mut pid = process.pid.to_string();
+    let mut pid = process.stat.pid.to_string();
     pid.push_str(&" ".repeat(pid_length - pid.len()));
 
     let padding = " ".repeat(4 * depth);
     println!("{}{}{}", pid, padding, cmdline);
 
-    let children = get_children(process.pid, all_processes);
+    let children = get_children(process.stat.pid, all_processes);
     for child in &children {
         print_process(child, &all_processes, depth + 1);
     }
@@ -53,7 +61,7 @@ fn print_process(process: &Process, all_processes: &Vec<Process>, depth: usize) 
 
 /// Get all children of a specific process, by iterating through all processes and
 /// checking their parent pid.
-pub fn get_children(pid: i32, all_processes: &Vec<Process>) -> Vec<&Process> {
+fn get_children(pid: i32, all_processes: &Vec<ProcessEntry>) -> Vec<&ProcessEntry> {
     all_processes
         .into_iter()
         .filter(|process| process.stat.ppid == pid)

--- a/examples/ps.rs
+++ b/examples/ps.rs
@@ -6,17 +6,20 @@ extern crate procfs;
 /// It shows all the processes that share the same tty as our self
 
 fn main() {
-    let me = procfs::process::Process::myself().unwrap();
+    let mestat = procfs::process::Process::myself().unwrap().stat().unwrap();
     let tps = procfs::ticks_per_second().unwrap();
 
-    println!("{: >5} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
+    println!("{: >10} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 
-    let tty = format!("pty/{}", me.stat.tty_nr().1);
-    for prc in procfs::process::all_processes().unwrap() {
-        if prc.stat.tty_nr == me.stat.tty_nr {
-            // total_time is in seconds
-            let total_time = (prc.stat.utime + prc.stat.stime) as f32 / (tps as f32);
-            println!("{: >5} {: <8} {: >8} {}", prc.stat.pid, tty, total_time, prc.stat.comm);
+    let tty = format!("pty/{}", mestat.tty_nr().1);
+    for p in procfs::process::all_processes().unwrap() {
+        let prc = p.unwrap();
+        if let Ok(stat) = prc.stat() {
+            if stat.tty_nr == mestat.tty_nr {
+                // total_time is in seconds
+                let total_time = (stat.utime + stat.stime) as f32 / (tps as f32);
+                println!("{: >10} {: <8} {: >8} {}", stat.pid, tty, total_time, stat.comm);
+            }
         }
     }
 }

--- a/examples/self_memory.rs
+++ b/examples/self_memory.rs
@@ -10,14 +10,16 @@ fn main() {
     // Note: when comparing the below values to what "top" will display, note that "top" will use
     // base-2 units (kibibytes), not base-10 units (kilobytes).
 
-    println!("== Data from /proc/self/stat:");
-    println!("Total virtual memory used: {} bytes", me.stat.vsize);
-    println!(
-        "Total resident set: {} pages ({} bytes)",
-        me.stat.rss,
-        me.stat.rss as u64 * page_size
-    );
-    println!();
+    if let Ok(stat) = me.stat() {
+        println!("== Data from /proc/self/stat:");
+        println!("Total virtual memory used: {} bytes", stat.vsize);
+        println!(
+            "Total resident set: {} pages ({} bytes)",
+            stat.rss,
+            stat.rss as u64 * page_size
+        );
+        println!();
+    }
 
     if let Ok(statm) = me.statm() {
         println!("== Data from /proc/self/statm:");

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,17 +17,19 @@
 //! > cargo run --example=netstat
 //!
 //! ```rust
-//! # use procfs::process::{Process, FDTarget};
+//! # use procfs::process::{FDTarget, Stat};
 //! # use std::collections::HashMap;
 //! let all_procs = procfs::process::all_processes().unwrap();
 //!
 //! // build up a map between socket inodes and processes:
-//! let mut map: HashMap<u32, &Process> = HashMap::new();
-//! for process in &all_procs {
-//!     if let Ok(fds) = process.fd() {
+//! // build up a map between socket inodes and processes:
+//! let mut map: HashMap<u32, Stat> = HashMap::new();
+//! for p in all_procs {
+//!     let process = p.unwrap();
+//!     if let (Ok(stat), Ok(fds)) = (process.stat(), process.fd()) {
 //!         for fd in fds {
-//!             if let FDTarget::Socket(inode) = fd.target {
-//!                 map.insert(inode, process);
+//!             if let FDTarget::Socket(inode) = fd.unwrap().target {
+//!                 map.insert(inode, stat.clone());
 //!             }
 //!         }
 //!     }
@@ -42,8 +44,8 @@
 //!     let local_address = format!("{}", entry.local_address);
 //!     let remote_addr = format!("{}", entry.remote_address);
 //!     let state = format!("{:?}", entry.state);
-//!     if let Some(process) = map.get(&entry.inode) {
-//!         println!("{:<26} {:<26} {:<15} {:<12} {}/{}", local_address, remote_addr, state, entry.inode, process.stat.pid, process.stat.comm);
+//!     if let Some(stat) = map.get(&entry.inode) {
+//!         println!("{:<26} {:<26} {:<15} {:<12} {}/{}", local_address, remote_addr, state, entry.inode, stat.pid, stat.comm);
 //!     } else {
 //!         // We might not always be able to find the process associated with this socket
 //!         println!("{:<26} {:<26} {:<15} {:<12} -", local_address, remote_addr, state, entry.inode);

--- a/src/process/limit.rs
+++ b/src/process/limit.rs
@@ -9,8 +9,7 @@ use libc::rlim_t;
 impl crate::process::Process {
     /// Return the limits for this process
     pub fn limits(&self) -> ProcResult<Limits> {
-        let path = self.root.join("limits");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, self.fd, "limits")?;
         Limits::from_reader(file)
     }
 }

--- a/src/process/mount.rs
+++ b/src/process/mount.rs
@@ -42,8 +42,7 @@ bitflags! {
 impl super::Process {
     /// Returns the [MountStat] data for this processes mount namespace.
     pub fn mountstats(&self) -> ProcResult<Vec<MountStat>> {
-        let path = self.root.join("mountstats");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, self.fd, "mountstats")?;
         MountStat::from_reader(file)
     }
 
@@ -53,8 +52,7 @@ impl super::Process {
     ///
     /// (Since Linux 2.6.26)
     pub fn mountinfo(&self) -> ProcResult<Vec<MountInfo>> {
-        let path = self.root.join("mountinfo");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, self.fd, "mountinfo")?;
         let bufread = BufReader::new(file);
         let lines = bufread.lines();
         let mut vec = Vec::new();

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -343,12 +343,13 @@ mod tests {
     #[test]
     fn test_proc_status() {
         let myself = Process::myself().unwrap();
+        let stat = myself.stat().unwrap();
         let status = myself.status().unwrap();
         println!("{:?}", status);
 
-        assert_eq!(status.name, myself.stat.comm);
-        assert_eq!(status.pid, myself.stat.pid);
-        assert_eq!(status.ppid, myself.stat.ppid);
+        assert_eq!(status.name, stat.comm);
+        assert_eq!(status.pid, stat.pid);
+        assert_eq!(status.ppid, stat.ppid);
     }
 
     #[test]

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -44,79 +44,79 @@ fn test_main_thread_task() {
 #[allow(clippy::cognitive_complexity)]
 #[test]
 fn test_self_proc() {
-    let myself = Process::myself().unwrap();
+    let myself = Process::myself().unwrap().stat().unwrap();
     println!("{:#?}", myself);
-    println!("state: {:?}", myself.stat.state());
-    println!("tty: {:?}", myself.stat.tty_nr());
-    println!("flags: {:?}", myself.stat.flags());
+    println!("state: {:?}", myself.state());
+    println!("tty: {:?}", myself.tty_nr());
+    println!("flags: {:?}", myself.flags());
 
     #[cfg(feature = "chrono")]
-    println!("starttime: {:#?}", myself.stat.starttime());
+    println!("starttime: {:#?}", myself.starttime());
 
     let kernel = KernelVersion::current().unwrap();
 
     if kernel >= KernelVersion::new(2, 1, 22) {
-        assert!(myself.stat.exit_signal.is_some());
+        assert!(myself.exit_signal.is_some());
     } else {
-        assert!(myself.stat.exit_signal.is_none());
+        assert!(myself.exit_signal.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 2, 8) {
-        assert!(myself.stat.processor.is_some());
+        assert!(myself.processor.is_some());
     } else {
-        assert!(myself.stat.processor.is_none());
+        assert!(myself.processor.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 5, 19) {
-        assert!(myself.stat.rt_priority.is_some());
+        assert!(myself.rt_priority.is_some());
     } else {
-        assert!(myself.stat.rt_priority.is_none());
+        assert!(myself.rt_priority.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 5, 19) {
-        assert!(myself.stat.rt_priority.is_some());
-        assert!(myself.stat.policy.is_some());
+        assert!(myself.rt_priority.is_some());
+        assert!(myself.policy.is_some());
     } else {
-        assert!(myself.stat.rt_priority.is_none());
-        assert!(myself.stat.policy.is_none());
+        assert!(myself.rt_priority.is_none());
+        assert!(myself.policy.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 6, 18) {
-        assert!(myself.stat.delayacct_blkio_ticks.is_some());
+        assert!(myself.delayacct_blkio_ticks.is_some());
     } else {
-        assert!(myself.stat.delayacct_blkio_ticks.is_none());
+        assert!(myself.delayacct_blkio_ticks.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 6, 24) {
-        assert!(myself.stat.guest_time.is_some());
-        assert!(myself.stat.cguest_time.is_some());
+        assert!(myself.guest_time.is_some());
+        assert!(myself.cguest_time.is_some());
     } else {
-        assert!(myself.stat.guest_time.is_none());
-        assert!(myself.stat.cguest_time.is_none());
+        assert!(myself.guest_time.is_none());
+        assert!(myself.cguest_time.is_none());
     }
 
     if kernel >= KernelVersion::new(3, 3, 0) {
-        assert!(myself.stat.start_data.is_some());
-        assert!(myself.stat.end_data.is_some());
-        assert!(myself.stat.start_brk.is_some());
+        assert!(myself.start_data.is_some());
+        assert!(myself.end_data.is_some());
+        assert!(myself.start_brk.is_some());
     } else {
-        assert!(myself.stat.start_data.is_none());
-        assert!(myself.stat.end_data.is_none());
-        assert!(myself.stat.start_brk.is_none());
+        assert!(myself.start_data.is_none());
+        assert!(myself.end_data.is_none());
+        assert!(myself.start_brk.is_none());
     }
 
     if kernel >= KernelVersion::new(3, 5, 0) {
-        assert!(myself.stat.arg_start.is_some());
-        assert!(myself.stat.arg_end.is_some());
-        assert!(myself.stat.env_start.is_some());
-        assert!(myself.stat.env_end.is_some());
-        assert!(myself.stat.exit_code.is_some());
+        assert!(myself.arg_start.is_some());
+        assert!(myself.arg_end.is_some());
+        assert!(myself.env_start.is_some());
+        assert!(myself.env_end.is_some());
+        assert!(myself.exit_code.is_some());
     } else {
-        assert!(myself.stat.arg_start.is_none());
-        assert!(myself.stat.arg_end.is_none());
-        assert!(myself.stat.env_start.is_none());
-        assert!(myself.stat.env_end.is_none());
-        assert!(myself.stat.exit_code.is_none());
+        assert!(myself.arg_start.is_none());
+        assert!(myself.arg_end.is_none());
+        assert!(myself.env_start.is_none());
+        assert!(myself.env_end.is_none());
+        assert!(myself.exit_code.is_none());
     }
 }
 
@@ -134,20 +134,22 @@ fn test_all() {
             })
         })
         .unwrap_or(false);
-    for prc in all_processes().unwrap() {
+    for p in all_processes().unwrap() {
         // note: this test doesn't unwrap, since some of this data requires root to access
         // so permission denied errors are common.  The check_unwrap helper function handles
         // this.
 
-        println!("{} {}", prc.pid(), prc.stat.comm);
-        prc.stat.flags().unwrap();
-        prc.stat.state().unwrap();
+        let prc = p.unwrap();
+        let stat = prc.stat().unwrap();
+        println!("{} {}", prc.pid(), stat.comm);
+        stat.flags().unwrap();
+        stat.state().unwrap();
         #[cfg(feature = "chrono")]
-        prc.stat.starttime().unwrap();
+        stat.starttime().unwrap();
 
         // if this process is defunct/zombie, don't try to read any of the below data
         // (some might be successful, but not all)
-        if prc.stat.state().unwrap() == ProcState::Zombie {
+        if stat.state().unwrap() == ProcState::Zombie {
             continue;
         }
 
@@ -218,7 +220,7 @@ fn test_error_handling() {
     // getting the proc struct should be OK
     let init = Process::new(1).unwrap();
 
-    let i_have_access = unsafe { libc::geteuid() } == init.owner;
+    let i_have_access = unsafe { libc::geteuid() } == init.metadata().unwrap().st_uid;
 
     if !i_have_access {
         // but accessing data should result in an error (unless we are running as root!)
@@ -269,7 +271,8 @@ fn test_mmap_path() {
 #[test]
 fn test_proc_fd() {
     let myself = Process::myself().unwrap();
-    for fd in myself.fd().unwrap() {
+    for f in myself.fd().unwrap() {
+        let fd = f.unwrap();
         println!("{:?} {:?}", fd, fd.mode());
     }
 }
@@ -330,7 +333,7 @@ fn test_procinfo() {
 
     let procinfo_stat = procinfo::pid::stat_self().unwrap();
     let me = Process::myself().unwrap();
-    let me_stat = me.stat;
+    let me_stat = me.stat().unwrap();
 
     diff_mem(procinfo_stat.vsize as f32, me_stat.vsize as f32);
 


### PR DESCRIPTION
All data accessors now use openat and readlinkat when reading procfs entries, to protect against PID reuse. Also, iterators are now used instead of `Vec` in any place where a file descriptor is held open. This is an API break, see examples/netstat.rs and examples/process_hierarchy.rs for the most obvious effects on library consumers. I also removed the `stat` field as suggested in #69. I haven't made any documentation changes yet, but I can if the approach here looks good.

A downside of this is that simple cases using `stat` are now slower. If all you need during iteration is the information from `/proc/<pid>/stat`, that now takes two additional syscalls to open and close the directory fd. We could speed that up by adding another function to iterate over the pids, and then adding more constructors to the relevant structures (`Stat`, `MemoryMap`, `Status`...) that directly reads from `/proc/<pid>/<name>`. It would have to be noted in the documentation that it's only safe to use one of those constructors while iterating, because of PID recycling; for cases where two or more files need to be read from within an individual `/proc/<pid>` directory, the fd-holding iterator from `all_processes()` must be used.

If this all sounds good, I'd like to use this as a base to add pidfd support as well, to support race-free waiting and signaling on procfs processes.

Fixes #125