### PR TITLE
Derive Clone for all public structs and enums.

### DIFF
--- a/src/cgroups.rs
+++ b/src/cgroups.rs
@@ -2,7 +2,7 @@ use crate::ProcResult;
 
 use super::process::Process;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Container group controller information.
 ///
 /// See also the [cgroups()] method.
@@ -64,7 +64,7 @@ pub fn cgroups() -> ProcResult<Vec<CGroupController>> {
 /// Information about a process cgroup
 ///
 /// See also the [Process::cgroups()] method.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProcessCgroup {
     /// For cgroups version 1 hierarchies, this field contains a  unique  hierarchy  ID  number
     /// that  can  be  matched  to  a  hierarchy  ID  in /proc/cgroups.  For the cgroups version 2

--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -10,7 +10,7 @@ use std::{collections::HashMap, io::Read};
 /// For common fields, there are methods that will return the data, converted to a more appropriate
 /// data type.  These methods will all return `None` if the field doesn't exist, or is in some
 /// unexpected format (in that case, you'll have to access the string data directly).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuInfo {
     /// This stores fields that are common among all CPUs
     pub fields: HashMap<String, String>,

--- a/src/diskstats.rs
+++ b/src/diskstats.rs
@@ -10,7 +10,7 @@ use std::io::{BufRead, BufReader};
 /// example in the source repo.
 // Doc reference: https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
 // Doc reference: https://www.kernel.org/doc/Documentation/iostats.txt
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DiskStat {
     /// The device major number
     pub major: i32,

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -100,7 +100,7 @@ impl KeyFlags {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Permissions {
     pub possessor: PermissionFlags,
     pub user: PermissionFlags,
@@ -130,7 +130,7 @@ impl Permissions {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum KeyTimeout {
     Permanent,
     Expired,
@@ -158,7 +158,7 @@ impl KeyTimeout {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum KeyType {
     /// This is a general-purpose key type.
     ///
@@ -221,7 +221,7 @@ impl KeyType {
 }
 
 /// A key
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Key {
     /// The ID (serial number) of the key
     pub id: u64,
@@ -302,7 +302,7 @@ pub fn keys() -> ProcResult<Vec<Key>> {
 }
 
 /// Information about a user with at least one key
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KeyUser {
     /// The user that owns the key
     pub uid: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ impl std::error::Error for ProcError {}
 ///
 /// Load averages are calculated as the number of jobs in the run queue (state R) or waiting for
 /// disk I/O (state D) averaged over 1, 5, and 15 minutes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LoadAverage {
     /// The one-minute load average
     pub one: f32,
@@ -655,7 +655,7 @@ pub fn page_size() -> std::io::Result<i64> {
 }
 
 /// Possible values for a kernel config option
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ConfigSetting {
     Yes,
     Module,
@@ -724,7 +724,7 @@ pub fn kernel_config() -> ProcResult<HashMap<String, ConfigSetting>> {
 
 /// To convert this value to seconds, you can divide by the tps.  There are also convenience methods
 /// that you can use too.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuTime {
     /// Ticks spent in user mode
     pub user: u64,
@@ -925,7 +925,7 @@ impl CpuTime {
 }
 
 /// Kernel/system statistics, from `/proc/stat`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KernelStats {
     /// The amount of time the system spent in various states
     pub total: CpuTime,
@@ -1029,7 +1029,7 @@ pub fn vmstat() -> ProcResult<HashMap<String, i64>> {
 ///
 /// For an example, see the [lsmod.rs](https://github.com/eminence/procfs/tree/master/examples)
 /// example in the source repo.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KernelModule {
     /// The name of the module
     pub name: String,

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -40,7 +40,7 @@ impl From<&str> for LockType {
 }
 
 /// The mode of a lock (advisory or mandatory)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum LockMode {
     Advisory,
     Mandatory,
@@ -70,7 +70,7 @@ impl From<&str> for LockMode {
 }
 
 /// The kind of a lock (read or write)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum LockKind {
     /// A read lock (or BSD shared lock)
     Read,
@@ -102,7 +102,7 @@ impl From<&str> for LockKind {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Details about an individual file lock
 ///
 /// See the [`locks`] function.

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -24,7 +24,7 @@ use super::{convert_to_kibibytes, FileWrapper, ProcResult};
 /// programs rely on /proc/meminfo to specify size with the "kB" string.
 ///
 /// New fields to this struct may be added at any time (even without a major or minor semver bump).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(non_snake_case)]
 pub struct Meminfo {
     // this private field prevents clients from directly constructing this object.

--- a/src/net.rs
+++ b/src/net.rs
@@ -60,7 +60,7 @@ use std::io::{BufRead, BufReader, Read};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{path::PathBuf, str::FromStr};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TcpState {
     Established = 1,
     SynSent,
@@ -113,7 +113,7 @@ impl TcpState {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UdpState {
     Established = 1,
     Close = 7,
@@ -136,7 +136,7 @@ impl UdpState {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum UnixState {
     UNCONNECTED = 1,
     CONNECTING = 2,
@@ -166,7 +166,7 @@ impl UnixState {
 }
 
 /// An entry in the TCP socket table
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TcpNetEntry {
     pub local_address: SocketAddr,
     pub remote_address: SocketAddr,
@@ -177,7 +177,7 @@ pub struct TcpNetEntry {
 }
 
 /// An entry in the UDP socket table
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UdpNetEntry {
     pub local_address: SocketAddr,
     pub remote_address: SocketAddr,
@@ -188,7 +188,7 @@ pub struct UdpNetEntry {
 }
 
 /// An entry in the Unix socket table
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnixNetEntry {
     /// The number of users of the socket
     pub ref_count: u32,
@@ -386,7 +386,7 @@ pub fn unix() -> ProcResult<Vec<UnixNetEntry>> {
 }
 
 /// An entry in the ARP table
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ARPEntry {
     /// IPv4 address
     pub ip_address: Ipv4Addr,

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 /// Pressure stall information for either CPU, memory, or IO.
 ///
 /// See also: https://www.kernel.org/doc/Documentation/accounting/psi.txt
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PressureRecord {
     /// 10 second window
     ///
@@ -33,7 +33,7 @@ pub struct PressureRecord {
 }
 
 /// CPU pressure information
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CpuPressure {
     pub some: PressureRecord,
 }
@@ -57,7 +57,7 @@ impl CpuPressure {
 }
 
 /// Memory pressure information
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MemoryPressure {
     /// This record indicates the share of time in which at least some tasks are stalled
     pub some: PressureRecord,
@@ -76,7 +76,7 @@ impl MemoryPressure {
 }
 
 /// IO pressure information
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IoPressure {
     /// This record indicates the share of time in which at least some tasks are stalled
     pub some: PressureRecord,

--- a/src/sys/fs/mod.rs
+++ b/src/sys/fs/mod.rs
@@ -7,7 +7,7 @@ pub mod binfmt_misc;
 pub mod epoll;
 
 /// Information about the status of the directory cache (dcache)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DEntryState {
     /// The number of allocated dentries (dcache entries)
     ///
@@ -61,7 +61,7 @@ pub fn file_max() -> ProcResult<usize> {
 pub fn set_file_max(max: usize) -> ProcResult<()> {
     write_value("/proc/sys/fs/file-max", max)
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileState {
     /// The number of allocated file handles.
     ///


### PR DESCRIPTION
Hey, really awesome work on this!

I'm using it for some tooling and I noticed that some of the structs cannot be cloned nor copied, so I just went ahead and implemented Clone for all the types that are public. 

I don't think there is any reason not to allow the structs to be cloned.
I did not derive Copy for any of them on purpose -- that allows
non-public fields to be added later that are not Copyable.