### PR TITLE
feat: create task by specify pid and tid

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1117,7 +1117,7 @@ impl Process {
 
     /// Return a task for the main thread of this process
     pub fn task_main_thread(&self) -> ProcResult<Task> {
-        Task::from_rel_path(self.pid, Path::new(&format!("{}", self.pid)))
+        Task::new(self.pid, self.pid)
     }
 
     /// Return the `Schedstat` for this process, based on the `/proc/<pid>/schedstat` file.

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -18,6 +18,18 @@ pub struct Task {
 }
 
 impl Task {
+    /// Create a new `Task` 
+    pub fn new(pid: i32, tid: i32) -> Result<Task, ProcError> {
+        let root = PathBuf::from(format!("/proc/{}/task/{}", pid, tid));
+        if root.exists() {
+            Ok(Task{
+                pid, tid, root
+            })
+        } else {
+            Err(ProcError::NotFound(Some(root)))
+        }
+    }
+
     /// Create a new `Task` inside of the process
     ///
     /// This API is designed to be ergonomic from inside of [`TasksIter`](super::TasksIter)


### PR DESCRIPTION
My usage scenario is to obtain the `pid` and `tid` through system calls, and then save them somewhere, and then obtain the information of the corresponding thread in the subsequent jobs. Therefore, it is very convenient to create a `Task` directly through `pid` and `tid`, just like creating a `Process` directly through `pid`.
With this method, `Process::task_main_thread` does not need to convert `tid` to `Path` first, which looks more clear.