### PR TITLE
Use u16 for kernel patch version number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1125,6 +1125,11 @@ mod tests {
         assert_eq!(k.major, 4);
         assert_eq!(k.minor, 9);
         assert_eq!(k.patch, 16);
+
+        let k = KernelVersion::from_str("4.9.266-0.1.ac.225.84.332.metal1.x86_64").unwrap();
+        assert_eq!(k.major, 4);
+        assert_eq!(k.minor, 9);
+        assert_eq!(k.patch, 266);
     }
 
     #[test]

--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -16,13 +16,13 @@ pub mod random;
 /// Represents a kernel version, in major.minor.release version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Version {
-    pub major: u16,
-    pub minor: u16,
-    pub patch: u32,
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u16,
 }
 
 impl Version {
-    pub fn new(major: u16, minor: u16, patch: u32) -> Version {
+    pub fn new(major: u8, minor: u8, patch: u16) -> Version {
         Version { major, minor, patch }
     }
 

--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -16,13 +16,13 @@ pub mod random;
 /// Represents a kernel version, in major.minor.release version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Version {
-    pub major: u32,
-    pub minor: u32,
+    pub major: u16,
+    pub minor: u16,
     pub patch: u32,
 }
 
 impl Version {
-    pub fn new(major: u32, minor: u32, patch: u32) -> Version {
+    pub fn new(major: u16, minor: u16, patch: u32) -> Version {
         Version { major, minor, patch }
     }
 

--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -16,13 +16,13 @@ pub mod random;
 /// Represents a kernel version, in major.minor.release version.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Version {
-    pub major: u8,
-    pub minor: u8,
-    pub patch: u8,
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
 }
 
 impl Version {
-    pub fn new(major: u8, minor: u8, patch: u8) -> Version {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Version {
         Version { major, minor, patch }
     }
 


### PR DESCRIPTION
- Added a previously failing test
- Fixes #136