### PR TITLE
Allow kernel patch version to be > 255

### DIFF
--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -18,11 +18,11 @@ pub mod random;
 pub struct Version {
     pub major: u8,
     pub minor: u8,
-    pub patch: u8,
+    pub patch: u16,
 }
 
 impl Version {
-    pub fn new(major: u8, minor: u8, patch: u8) -> Version {
+    pub fn new(major: u8, minor: u8, patch: u16) -> Version {
         Version { major, minor, patch }
     }
 
@@ -327,6 +327,10 @@ mod tests {
 
         let a = Version::from_str("3.16.0_1").unwrap();
         let b = Version::new(3, 16, 0);
+        assert_eq!(a, b);
+        
+        let a = Version::from_str("4.9.268-perf+-ab76").unwrap();
+        let b = Version::new(4, 9, 268);
         assert_eq!(a, b);
     }
 


### PR DESCRIPTION
While it's unlikely that the major and minor version won't fit in an `u8`, I had the case of a kernel patch version overflow. Since the lazy static `KERNEL` just calls `KernelVersion::current().unwrap()` this is causing crashes.

This patch switches to a `u16` and adds a matching test.