### PR TITLE
Unpin hex and bitflags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,15 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.toolchain }}
+    
+    - name: Pin hex and bitflags
+      if: matrix.toolchain == '1.34.0' || matrix.toolchain == '1.42.0'
+      run: |
+        cargo +${{ matrix.toolchain }} update
+        cargo +${{ matrix.toolchain }} update --manifest-path procfs-tests/Cargo.toml
+        cargo +${{ matrix.toolchain }} update -p hex --precise 0.4.2
+        cargo +${{ matrix.toolchain }} update -p bitflags --precise 1.2.1
+        cargo +${{ matrix.toolchain }} update --manifest-path procfs-tests/Cargo.toml -p bitflags --precise 1.2.1
 
     - name: Build
       run: cargo +${{ matrix.toolchain }} build --verbose
@@ -50,6 +59,13 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: aarch64-linux-android
+
+      - name: Pin hex and bitflags
+        if:  matrix.toolchain == '1.42.0'
+        run: |
+          cargo +${{ matrix.toolchain }} update
+          cargo +${{ matrix.toolchain }} update -p hex --precise 0.4.2
+          cargo +${{ matrix.toolchain }} update -p bitflags --precise 1.2.1
 
       - name: cargo check
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ default = ["chrono"]
 
 [dependencies]
 libc = "0.2"
-bitflags = "~1.2"
+bitflags = "1.2"
 lazy_static = "1"
 chrono = {version = "0.4", optional = true }
 byteorder = {version="1", features=["i128"]}
-hex = "=0.4.2"
+hex = "0.4"
 flate2 = "1"
 backtrace = { version = "0.3", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ The following cargo features are available:
 ## Minimum Rust Version
 
 This crate requires a minimum rust version of 1.34.0 (2019-04-11), though if you use the optional `backtrace` feature,
-rust 1.42.0 is required (2020-03-12).
+rust 1.42.0 is required (2020-03-12).  However, two dependencies of this crate (`hex` and `bitflags`) require a newer
+version of rust, and must be manually pinned to an older version in order to use rust 1.34.  You can do this by running:
+
+    cargo update -p hex --precise 0.4.2
+    cargo update -p bitflags --precise 1.2.1
 
 ## License
 


### PR DESCRIPTION
Pinning these versions caused problems when using procfs with other
crates that had conflicting requirements.  Unpin these versions and
update the README with instructions on how downstream users can manually
select what version of hex and bitflags to use

Closes #144