### PR TITLE
Switch to u64 from usize in many places

### DIFF
--- a/src/diskstats.rs
+++ b/src/diskstats.rs
@@ -24,65 +24,65 @@ pub struct DiskStat {
     /// Reads completed successfully
     ///
     /// This is the total number of reads completed successfully
-    pub reads: usize,
+    pub reads: u64,
 
     /// Reads merged
     ///
     /// The number of adjacent reads that have been merged for efficiency.
-    pub merged: usize,
+    pub merged: u64,
 
     /// Sectors read successfully
     ///
     /// This is the total number of sectors read successfully.
-    pub sectors_read: usize,
+    pub sectors_read: u64,
 
     /// Time spent reading (ms)
-    pub time_reading: usize,
+    pub time_reading: u64,
 
     /// writes completed
-    pub writes: usize,
+    pub writes: u64,
 
     /// writes merged
     ///
     /// The number of adjacent writes that have been merged for efficiency.
-    pub writes_merged: usize,
+    pub writes_merged: u64,
 
     /// Sectors written successfully
-    pub sectors_written: usize,
+    pub sectors_written: u64,
 
     /// Time spent writing (ms)
-    pub time_writing: usize,
+    pub time_writing: u64,
 
     /// I/Os currently in progress
-    pub in_progress: usize,
+    pub in_progress: u64,
 
     /// Time spent doing I/Os (ms)
-    pub time_in_progress: usize,
+    pub time_in_progress: u64,
 
     /// Weighted time spent doing I/Os (ms)
-    pub weighted_time_in_progress: usize,
+    pub weighted_time_in_progress: u64,
 
     /// Discards completed successfully
     ///
     /// (since kernel 4.18)
-    pub discards: Option<usize>,
+    pub discards: Option<u64>,
 
     /// Discards merged
-    pub discards_merged: Option<usize>,
+    pub discards_merged: Option<u64>,
 
     /// Sectors discarded
-    pub sectors_discarded: Option<usize>,
+    pub sectors_discarded: Option<u64>,
 
     /// Time spent discarding
-    pub time_discarding: Option<usize>,
+    pub time_discarding: Option<u64>,
 
     /// Flush requests completed successfully
     ///
     /// (since kernel 5.5)
-    pub flushes: Option<usize>,
+    pub flushes: Option<u64>,
 
     /// Time spent flushing
-    pub time_flushing: Option<usize>,
+    pub time_flushing: Option<u64>,
 }
 
 /// Get disk IO stat info from /proc/diskstats
@@ -105,23 +105,23 @@ impl DiskStat {
         let major = from_str!(i32, expect!(s.next()));
         let minor = from_str!(i32, expect!(s.next()));
         let name = expect!(s.next()).to_string();
-        let reads = from_str!(usize, expect!(s.next()));
-        let merged = from_str!(usize, expect!(s.next()));
-        let sectors_read = from_str!(usize, expect!(s.next()));
-        let time_reading = from_str!(usize, expect!(s.next()));
-        let writes = from_str!(usize, expect!(s.next()));
-        let writes_merged = from_str!(usize, expect!(s.next()));
-        let sectors_written = from_str!(usize, expect!(s.next()));
-        let time_writing = from_str!(usize, expect!(s.next()));
-        let in_progress = from_str!(usize, expect!(s.next()));
-        let time_in_progress = from_str!(usize, expect!(s.next()));
-        let weighted_time_in_progress = from_str!(usize, expect!(s.next()));
-        let discards = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
-        let discards_merged = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
-        let sectors_discarded = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
-        let time_discarding = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
-        let flushes = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
-        let time_flushing = s.next().and_then(|s| usize::from_str_radix(s, 10).ok());
+        let reads = from_str!(u64, expect!(s.next()));
+        let merged = from_str!(u64, expect!(s.next()));
+        let sectors_read = from_str!(u64, expect!(s.next()));
+        let time_reading = from_str!(u64, expect!(s.next()));
+        let writes = from_str!(u64, expect!(s.next()));
+        let writes_merged = from_str!(u64, expect!(s.next()));
+        let sectors_written = from_str!(u64, expect!(s.next()));
+        let time_writing = from_str!(u64, expect!(s.next()));
+        let in_progress = from_str!(u64, expect!(s.next()));
+        let time_in_progress = from_str!(u64, expect!(s.next()));
+        let weighted_time_in_progress = from_str!(u64, expect!(s.next()));
+        let discards = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
+        let discards_merged = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
+        let sectors_discarded = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
+        let time_discarding = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
+        let flushes = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
+        let time_flushing = s.next().and_then(|s| u64::from_str_radix(s, 10).ok());
 
         Ok(DiskStat {
             major,

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -133,12 +133,12 @@ pub struct Lock {
     /// The offset (in bytes) of the first byte of the lock.
     ///
     /// For BSD locks, this value is always 0.
-    pub offset_first: usize,
+    pub offset_first: u64,
     /// The offset (in bytes) of the last byte of the lock.
     ///
     /// `None` means the lock extends to the end of the file.  For BSD locks,
     /// the value is always `None`.
-    pub offset_last: Option<usize>,
+    pub offset_last: Option<u64>,
 }
 
 impl Lock {
@@ -159,7 +159,7 @@ impl Lock {
         let kind = From::from(expect!(s.next()));
         let pid = expect!(s.next());
         let disk_inode = expect!(s.next());
-        let offset_first = from_str!(usize, expect!(s.next()));
+        let offset_first = from_str!(u64, expect!(s.next()));
         let offset_last = expect!(s.next());
 
         let mut dis = disk_inode.split(':');
@@ -179,7 +179,7 @@ impl Lock {
             offset_last: if offset_last == "EOF" {
                 None
             } else {
-                Some(from_str!(usize, offset_last))
+                Some(from_str!(u64, offset_last))
             },
         })
     }

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -208,31 +208,31 @@ pub struct Stat {
     /// Address above which program initialized and uninitialized (BSS) data are placed.
     ///
     /// (since Linux 3.3)
-    pub start_data: Option<usize>,
+    pub start_data: Option<u64>,
     /// Address below which program initialized and uninitialized (BSS) data are placed.
     ///
     /// (since Linux 3.3)
-    pub end_data: Option<usize>,
+    pub end_data: Option<u64>,
     /// Address above which program heap can be expanded with brk(2).
     ///
     /// (since Linux 3.3)
-    pub start_brk: Option<usize>,
+    pub start_brk: Option<u64>,
     /// Address above which program command-line arguments (argv) are placed.
     ///
     /// (since Linux 3.5)
-    pub arg_start: Option<usize>,
+    pub arg_start: Option<u64>,
     /// Address below program command-line arguments (argv) are placed.
     ///
     /// (since Linux 3.5)
-    pub arg_end: Option<usize>,
+    pub arg_end: Option<u64>,
     /// Address above which program environment is placed.
     ///
     /// (since Linux 3.5)
-    pub env_start: Option<usize>,
+    pub env_start: Option<u64>,
     /// Address below which program environment is placed.
     ///
     /// (since Linux 3.5)
-    pub env_end: Option<usize>,
+    pub env_end: Option<u64>,
     /// The thread's exit status in the form reported by waitpid(2).
     ///
     /// (since Linux 3.5)

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -18,13 +18,11 @@ pub struct Task {
 }
 
 impl Task {
-    /// Create a new `Task` 
+    /// Create a new `Task`
     pub fn new(pid: i32, tid: i32) -> Result<Task, ProcError> {
         let root = PathBuf::from(format!("/proc/{}/task/{}", pid, tid));
         if root.exists() {
-            Ok(Task{
-                pid, tid, root
-            })
+            Ok(Task { pid, tid, root })
         } else {
             Err(ProcError::NotFound(Some(root)))
         }


### PR DESCRIPTION
Apologies for such a long delay, work got in the way.

I've implemented the base changes needed to fix https://github.com/eminence/procfs/issues/141. Both diskstats and stat were changed to use `u64`. I've noticed my NAS having diskstat numbers in the tens of billions so I thought the change there was appropriate. Some places I'm still not sure what to do about:

`sys/vm` `admin_reserve_kbytes` was kept as usize, as it would not make much sense to reserve billions of kilobytes.
`sys/fs` `file_max` was kept as usize, since I am not sure where would billions of files be opened.

However, both of these are rather arbitrary, and could be changed to u64. If you'd like that I'll be glad to make the change.

In the end, procfs now works just fine as a 32-bit executable on 64-bit machines.