### PR TITLE
MMapPath::Vsys for /SYSV pseudo files

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -467,7 +467,7 @@ pub enum MMapPath {
     /// An anonymous mapping as obtained via mmap(2).
     Anonymous,
     /// Shared memory segment
-    Vsys(u32),
+    Vsys(i32),
     /// Some other pseudo-path
     Other(String),
 }
@@ -492,7 +492,7 @@ impl MMapPath {
                 MMapPath::TStack(tid)
             }
             x if x.starts_with('[') && x.ends_with(']') => MMapPath::Other(x[1..x.len() - 1].to_string()),
-            x if x.starts_with("/SYSV") => MMapPath::Vsys(u32::from_str_radix(&x[5..13], 16)?), // 32bits as hex. /SYSVaabbccdd (deleted)
+            x if x.starts_with("/SYSV") => MMapPath::Vsys(i32::from_str_radix(&x[5..13], 16)?), // 32bits as hex. /SYSVaabbccdd (deleted)
             x => MMapPath::Path(PathBuf::from(x)),
         })
     }


### PR DESCRIPTION
Shared memory segments are displayed as `/SYSV<key> (deleted)` in `/proc/<pid>/maps` or `smaps`, where key is related to the key field in `ipcs -m` or `cat /proc/sysvipc/shm`

Examples:
```
$ sudo cat /proc/*/maps | grep /SYSV
7ff8ac138000-7ff8ac1b8000 rw-s 00000000 00:01 4                          /SYSV00000000 (deleted)
9f800000-9ff47000 rw-s 00000000 00:01 7                                  /SYSV00000000 (deleted)
a0000000-a0006000 rw-s 00000000 00:01 8                                  /SYSVba5bd51c (deleted)
```

```
$ ipcs -m

------ Shared Memory Segments --------
key        shmid      owner      perms      bytes      nattch     status      
0x00000000 4          tatref     600        524288     2          dest         
0x00000000 5          oracle     600        9146368    130                     
0x00000000 6          oracle     600        1052770304 65                      
0x00000000 7          oracle     600        7630848    65                      
0xba5bd51c 8          oracle     600        24576      65
```

This commits adds a variant in the `MMapPath` enum that contains a `i32` (the key parsed from hex)


