### PR TITLE
fix: 32bit signed int

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -492,7 +492,7 @@ impl MMapPath {
                 MMapPath::TStack(tid)
             }
             x if x.starts_with('[') && x.ends_with(']') => MMapPath::Other(x[1..x.len() - 1].to_string()),
-            x if x.starts_with("/SYSV") => MMapPath::Vsys(i32::from_str_radix(&x[5..13], 16)?), // 32bits as hex. /SYSVaabbccdd (deleted)
+            x if x.starts_with("/SYSV") => MMapPath::Vsys(u32::from_str_radix(&x[5..13], 16)? as i32), // 32bits signed hex. /SYSVaabbccdd (deleted)
             x => MMapPath::Path(PathBuf::from(x)),
         })
     }


### PR DESCRIPTION
Previous code had some issues...

    called `Result::unwrap()` on an `Err` value: Other("Value in `Key: Value` pair was not actually a number")

Hex values should be interpreted as a 32bits two's complement signed int