### PR TITLE
Document support for /proc/pressure/{cpu,io,memory}

### DIFF
--- a/support.md
+++ b/support.md
@@ -113,6 +113,10 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
   * [ ] `/proc/net/netfilter/nfnetlink_queue`
 * [ ] `/proc/partitions`
 * [ ] `/proc/pci`
+* [x] `/proc/pressure`
+  * [x] `/proc/pressure/cpu`
+  * [x] `/proc/pressure/io`
+  * [x] `/proc/pressure/memory`
 * [ ] `/proc/profile`
 * [ ] `/proc/scsi`
 * [ ] `/proc/scsi/scsi`


### PR DESCRIPTION
Seems that reading PSI from /proc/pressure/* has been implemented. But it's missing in the support document.