### PR TITLE
Add support for /proc/net/route

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -628,6 +628,74 @@ pub fn dev_status() -> ProcResult<HashMap<String, DeviceStatus>> {
     Ok(map)
 }
 
+/// An entry in the ipv4 route table
+#[derive(Debug, Clone)]
+pub struct RouteEntry {
+    /// Interface to which packets for this route will be sent
+    pub iface: String,
+    /// The destination network or destination host
+    pub destination: Ipv4Addr,
+    pub gateway: Ipv4Addr,
+    pub flags: u16,
+    /// Number of references to this route
+    pub refcnt: u16,
+    /// Count of lookups for the route
+    pub in_use: u16,
+    /// The 'distance' to the target (usually counted in hops)
+    pub metrics: u32,
+    pub mask: Ipv4Addr,
+    /// Default maximum transmission unit for TCP connections over this route
+    pub mtu: u32,
+    /// Default window size for TCP connections over this route
+    pub window: u32,
+    /// Initial RTT (Round Trip Time)
+    pub irtt: u32,
+}
+
+/// Reads the ipv4 route table
+///
+/// This data is from the `/proc/net/route` file
+pub fn route() -> ProcResult<Vec<RouteEntry>> {
+    let file = FileWrapper::open("/proc/net/route")?;
+    let reader = BufReader::new(file);
+
+    let mut vec = Vec::new();
+
+    // First line is a header we need to skip
+    for line in reader.lines().skip(1) {
+        // Check if there might have been an IO error.
+        let line = line?;
+        let mut line = line.split_whitespace();
+        // network interface name, e.g. eth0
+        let iface = expect!(line.next());
+        let destination = from_str!(u32, expect!(line.next()), 16).to_ne_bytes().into();
+        let gateway = from_str!(u32, expect!(line.next()), 16).to_ne_bytes().into();
+        let flags = from_str!(u16, expect!(line.next()), 16);
+        let refcnt = from_str!(u16, expect!(line.next()), 10);
+        let in_use = from_str!(u16, expect!(line.next()), 10);
+        let metrics = from_str!(u32, expect!(line.next()), 10);
+        let mask = from_str!(u32, expect!(line.next()), 16).to_ne_bytes().into();
+        let mtu = from_str!(u32, expect!(line.next()), 10);
+        let window = from_str!(u32, expect!(line.next()), 10);
+        let irtt = from_str!(u32, expect!(line.next()), 10);
+        vec.push(RouteEntry {
+            iface: iface.to_string(),
+            destination,
+            gateway,
+            flags,
+            refcnt,
+            in_use,
+            metrics,
+            mask,
+            mtu,
+            window,
+            irtt,
+        });
+    }
+
+    Ok(vec)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -718,6 +786,13 @@ mod tests {
     #[test]
     fn test_arp() {
         for entry in arp().unwrap() {
+            println!("{:?}", entry);
+        }
+    }
+
+    #[test]
+    fn test_route() {
+        for entry in route().unwrap() {
             println!("{:?}", entry);
         }
     }

--- a/support.md
+++ b/support.md
@@ -100,12 +100,14 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
 * [ ] `/proc/mounts`
 * [ ] `/proc/mtrr`
 * [ ] `/proc/net`
-  * [ ] `/proc/net/arp`
+  * [x] `/proc/net/arp`
   * [x] `/proc/net/dev`
   * [ ] `/proc/net/dev_mcast`
   * [ ] `/proc/net/igmp`
+  * [ ] `/proc/net/ipv6_route`
   * [ ] `/proc/net/rarp`
   * [ ] `/proc/net/raw`
+  * [x] `/proc/net/route`
   * [ ] `/proc/net/snmp`
   * [x] `/proc/net/tcp`
   * [x] `/proc/net/udp`


### PR DESCRIPTION
output example:

```
[w@ww ~]$ cat /proc/net/route 
Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT                                          
wlp4s0  00000000        0112A8C0        0003    0       0       600     00000000        0       0       0                                             
```

```
RouteEntry { iface: "wlp4s0", destination: 0.0.0.0, gateway: 192.168.18.1, flags: 3, refcnt: 0, use: 0, metrics: 600, mask: 0.0.0.0, mtu: 0, window: 0, irtt: 0 }
```