### PR TITLE
Do not run test_task in parallel with other tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Build
       run: cargo +${{ matrix.toolchain }} build --verbose
     - name: Run tests
-      run: cargo +${{ matrix.toolchain }} test --verbose
+      run: cargo +${{ matrix.toolchain }} test --verbose -- --skip _runsinglethread
+    - name: Run tests (single-threaded tests)
+      run: cargo +${{ matrix.toolchain }} test --verbose -- _runsinglethread --test-threads 1
 
     - name: Run more tests
       if: matrix.toolchain != '1.34.0'

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -76,7 +76,8 @@ mod tests {
 
     #[test]
     #[cfg(not(tarpaulin))] // this test is unstable under tarpaulin, and i'm yet sure why
-    fn test_task() {
+    // When this test runs in CI, run it single-threaded
+    fn test_task_runsinglethread() {
         use std::io::Read;
 
         let me = crate::process::Process::myself().unwrap();


### PR DESCRIPTION
This test often fails in CI, and I think this is because other tests
are running in parallel threads, causing this test to fail when it
tries to iterate over other running threads.

Any test can be run in a single-threaded mode by appending
`_runsinglethread` to its name