### PR TITLE
Add build-script to provide a nicely readable error if on unsupported platform

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Filters are extracted from `libc` filters
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "linux", target_os = "l4re",
+    )))]
+    compile_error!("Building procfs on an for a unsupported platform. Currently only linux and android are supported")
+}


### PR DESCRIPTION
This PR is aimed to provide a more informative build failure to users that are building `procfs` library targeting a platform different than linux or android.

The reason for this is that I was eventually planning to contribute to the library and while building it, on MacOS, the library was failing with a very odd error that lead me to look for a possible bug while instead the library is not really meant to be built on MacOS
```
   Compiling procfs v0.12.0 (/Users/maci/github/procfs)
error[E0433]: failed to resolve: could not find `linux` in `os`
  --> src/process/mod.rs:66:14
   |
66 | use std::os::linux::fs::MetadataExt;
   |              ^^^^^ could not find `linux` in `os`

error[E0425]: cannot find function `stat64` in crate `libc`
   --> src/process/namespaces.rs:25:31
    |
25  |             if unsafe { libc::stat64(cstr.as_ptr(), &mut stat) } != 0 {
    |                               ^^^^^^ help: a function with a similar name exists: `stat`
    |
   ::: /Users/maci/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.119/src/unix/mod.rs:715:5
    |
715 |     pub fn stat(path: *const c_char, buf: *mut stat) -> ::c_int;
    |     ------------------------------------------------------------ similarly named function `stat` defined here

```

With the code in the PR the built would fail, as expected, but with a much nicer error
```
error: failed to run custom build command for `procfs v0.12.0 (/Users/maci/github/procfs)`

Caused by:
  process didn't exit successfully: `/Users/maci/github/procfs/target/debug/build/procfs-c7cdf625ccdd8b75/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Building procfs on an for a unsupported platform. Currently only linux and android are supported', build.rs:7:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```