### PR TITLE
Improve `CpuInfo` performances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,13 @@ flate2 = { version = "1", optional = true }
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
+criterion = "0.3"
 procinfo = "0.4.2"
 failure = "0.1"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "cpuinfo"
+harness = false

--- a/benches/cpuinfo.rs
+++ b/benches/cpuinfo.rs
@@ -1,0 +1,16 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use procfs::CpuInfo;
+
+fn bench_cpuinfo(c: &mut Criterion) {
+    c.bench_function("CpuInfo::new", |b| b.iter(|| black_box(CpuInfo::new().unwrap())));
+
+    let cpuinfo = black_box(CpuInfo::new().unwrap());
+    c.bench_function("CpuInfo::get_info", |b| b.iter(|| black_box(cpuinfo.get_info(0))));
+    c.bench_function("CpuInfo::model_name", |b| b.iter(|| cpuinfo.model_name(0)));
+    c.bench_function("CpuInfo::vendor_id", |b| b.iter(|| cpuinfo.vendor_id(0)));
+    c.bench_function("CpuInfo::physical_id", |b| b.iter(|| cpuinfo.physical_id(0)));
+    c.bench_function("CpuInfo::flags", |b| b.iter(|| cpuinfo.flags(0)));
+}
+
+criterion_group!(benches, bench_cpuinfo);
+criterion_main!(benches);

--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -122,32 +122,30 @@ impl CpuInfo {
     }
 
     /// Get the content of a specific field associated to a CPU
-    /// 
+    ///
     /// Returns None if the requested cpu index is not found.
     pub fn get_field(&self, cpu_num: usize, field_name: &str) -> Option<&str> {
-        self.cpus.get(cpu_num).and_then(
-            |cpu_fields| {
-                cpu_fields.get(field_name).or_else(|| self.fields.get(field_name)).map(|s| s.as_ref())
-            }
-        )
+        self.cpus.get(cpu_num).and_then(|cpu_fields| {
+            cpu_fields
+                .get(field_name)
+                .or_else(|| self.fields.get(field_name))
+                .map(|s| s.as_ref())
+        })
     }
 
     pub fn model_name(&self, cpu_num: usize) -> Option<&str> {
-        self.get_info(cpu_num).and_then(|mut m| m.remove("model name"))
+        self.get_field(cpu_num, "model name")
     }
     pub fn vendor_id(&self, cpu_num: usize) -> Option<&str> {
-        self.get_info(cpu_num).and_then(|mut m| m.remove("vendor_id"))
+        self.get_field(cpu_num, "vendor_id")
     }
     /// May not be available on some older 2.6 kernels
     pub fn physical_id(&self, cpu_num: usize) -> Option<u32> {
-        self.get_info(cpu_num)
-            .and_then(|mut m| m.remove("physical id"))
-            .and_then(|s| u32::from_str_radix(s, 10).ok())
+        self.get_field(cpu_num, "physical id").and_then(|s| s.parse().ok())
     }
     pub fn flags(&self, cpu_num: usize) -> Option<Vec<&str>> {
-        self.get_info(cpu_num)
-            .and_then(|mut m| m.remove("flags"))
-            .map(|flags: &str| flags.split_whitespace().collect())
+        self.get_field(cpu_num, "flags")
+            .map(|flags| flags.split_whitespace().collect())
     }
 }
 

--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -104,23 +104,14 @@ impl CpuInfo {
     ///
     /// Returns None if the requested cpu index is not found.
     pub fn get_info(&self, cpu_num: usize) -> Option<HashMap<&str, &str>> {
-        if let Some(info) = self.cpus.get(cpu_num) {
-            let mut map = HashMap::new();
-
-            for (k, v) in &self.fields {
-                map.insert(k.as_ref(), v.as_ref());
-            }
-
-            for (k, v) in info.iter() {
-                map.insert(k.as_ref(), v.as_ref());
-            }
-
-            Some(map)
-        } else {
-            None
-        }
+        self.cpus.get(cpu_num).map(|info| {
+            self.fields
+                .iter()
+                .chain(info.iter())
+                .map(|(k, v)| (k.as_ref(), v.as_ref()))
+                .collect()
+        })
     }
-
     /// Get the content of a specific field associated to a CPU
     ///
     /// Returns None if the requested cpu index is not found.

--- a/src/cpuinfo.rs
+++ b/src/cpuinfo.rs
@@ -121,6 +121,17 @@ impl CpuInfo {
         }
     }
 
+    /// Get the content of a specific field associated to a CPU
+    /// 
+    /// Returns None if the requested cpu index is not found.
+    pub fn get_field(&self, cpu_num: usize, field_name: &str) -> Option<&str> {
+        self.cpus.get(cpu_num).and_then(
+            |cpu_fields| {
+                cpu_fields.get(field_name).or_else(|| self.fields.get(field_name)).map(|s| s.as_ref())
+            }
+        )
+    }
+
     pub fn model_name(&self, cpu_num: usize) -> Option<&str> {
         self.get_info(cpu_num).and_then(|mut m| m.remove("model name"))
     }

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -378,7 +378,9 @@ impl Meminfo {
             file_huge_pages: map.remove("FileHugePages"),
         };
 
-        assert!(!cfg!(test) || map.is_empty(), "meminfo map is not empty: {:#?}", map);
+        if cfg!(test) {
+            assert!(map.is_empty(), "meminfo map is not empty: {:#?}", map);
+        }
 
         Ok(meminfo)
     }


### PR DESCRIPTION
This PR is mostly meant to reduce needless memory allocations, and consequent performance drop, while attempting to extract a specific field for a CPU.

The methods, like `model_name`, were mostly defined as
* build the whole map of fields (<- building the map requires memory allocation)
* get the field from the built map

Considering that the field could be on the CPU specific fields or on the common fields, it feels natural to build an helper `CpuInfo::get_field` which takes care of finding and returning the field without materialising any map.

Moreover, the `CpuInfo::get_info` could be improved in performances by leveraging iterators and reduction of allocations provided by the compiler (context in 94a2cb84cd7a2bedac5ccfaff3a745224fc28baf commit message).

Below I present the results evaluated by running `cargo +nightly bench`

---

Results
```
CpuInfo::new            time:   [193.16 us 194.82 us 196.75 us]                         
                        change: [-30.504% -29.923% -29.304%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

CpuInfo::get_info       time:   [736.84 ns 739.73 ns 742.93 ns]                               
                        change: [-65.657% -65.373% -65.031%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

CpuInfo::model_name     time:   [39.954 ns 40.208 ns 40.480 ns]                                 
                        change: [-98.096% -98.069% -98.045%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

CpuInfo::vendor_id      time:   [39.386 ns 39.587 ns 39.797 ns]                                
                        change: [-98.101% -98.089% -98.078%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

CpuInfo::physical_id    time:   [23.572 ns 24.040 ns 24.555 ns]                                  
                        change: [-98.871% -98.848% -98.824%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

CpuInfo::flags          time:   [1.4871 us 1.5336 us 1.5761 us]                            
                        change: [-65.732% -64.875% -64.048%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

NOTE: I could split this PR in 2 blocks (before and after 3bfaf1ecb004b45e7220ec6f13a4227741896f81) such that we could add https://github.com/boa-dev/criterion-compare-action GH Action to have performance improvements automatically published on the PR (@edigaryev please share your thoughts)