### PR TITLE
Fix a race condition in the `test_task_runsinglethread` test.

### DIFF
--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -160,10 +160,8 @@ mod tests {
                 found_two = true;
                 // The process might read miscellaneous things from procfs or
                 // things like /sys/devices/system/cpu/online; allow some small
-                // reads, but make sure we're not looking at the thread that
-                // read `bytes_to_read` bytes.
+                // reads.
                 assert!(io.rchar < bytes_to_read);
-                assert_eq!(io.read_bytes, 0);
                 assert_eq!(io.wchar, 0);
                 assert_eq!(stat.utime, 0);
             }

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -158,7 +158,13 @@ mod tests {
             }
             if stat.comm == "two" && status.name == "two" {
                 found_two = true;
-                assert_eq!(io.rchar, 0);
+                // The process might read miscellaneous things from procfs or
+                // things like /sys/devices/system/cpu/online; allow some small
+                // reads, but make sure we're not looking at the thread that
+                // read `bytes_to_read` bytes.
+                assert!(io.rchar < bytes_to_read);
+                assert_eq!(io.read_bytes, 0);
+                assert_eq!(io.wchar, 0);
                 assert_eq!(stat.utime, 0);
             }
         }


### PR DESCRIPTION
`test_task_runsinglethread` spawns a thread which intends to do no I/O,
and checks that its `rchar` io value is 0. However, glibc sometimes
reads from /sys/devices/system/cpu/online, which sometimes happens on
this thread, and that causes a non-zero `rchar` value. The fix here is
to only require `rchar` to be less than the number of bytes that the
other thread reads. Also, check that `read_bytes` returns 0 since it
doesn't include bytes read from sysfs, and check that `wchar` is 0.