### PR TITLE
Revive RFC: Change Process to use directory fd

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        toolchain: ["1.42.0", "stable", "beta", "nightly"]
+        toolchain: ["1.48.0", "stable", "beta", "nightly"]
     runs-on: ubuntu-latest
 
     steps:
@@ -19,12 +19,6 @@ jobs:
       with:
         toolchain: ${{ matrix.toolchain }}
     
-    - name: Pin bitflags
-      if: matrix.toolchain == '1.42.0'
-      run: |
-        cargo +${{ matrix.toolchain }} update
-        cargo +${{ matrix.toolchain }} update -p bitflags --precise 1.2.1
-
     - name: Build
       run: cargo +${{ matrix.toolchain }} build --verbose
     - name: Run tests
@@ -42,7 +36,7 @@ jobs:
   check:
     strategy:
       matrix:
-        toolchain: ["1.42.0", "stable", "beta", "nightly"]
+        toolchain: ["1.48.0", "stable", "beta", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,13 +51,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: i686-unknown-linux-gnu
-
-      - name: Pin hex and bitflags
-        if:  matrix.toolchain == '1.42.0'
-        run: |
-          cargo +${{ matrix.toolchain }} update
-          cargo +${{ matrix.toolchain }} update -p hex --precise 0.4.2
-          cargo +${{ matrix.toolchain }} update -p bitflags --precise 1.2.1
 
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 default = ["chrono", "flate2"]
 
 [dependencies]
-rustix = "0.33.4"
+rustix = "0.34.0"
 bitflags = "1.2"
 lazy_static = "1"
 chrono = {version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 default = ["chrono", "flate2"]
 
 [dependencies]
-libc = "0.2"
+rustix = "0.33.4"
 bitflags = "1.2"
 lazy_static = "1"
 chrono = {version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ procfs
 
 [![Crate](https://img.shields.io/crates/v/procfs.svg)](https://crates.io/crates/procfs)
 [![Docs](https://docs.rs/procfs/badge.svg)](https://docs.rs/procfs)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.34+-lightgray.svg)](https://github.com/eminence/procfs#minimum-rust-version)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.48+-lightgray.svg)](https://github.com/eminence/procfs#minimum-rust-version)
 
 
 This crate is an interface to the `proc` pseudo-filesystem on linux, which is normally mounted as `/proc`.
@@ -72,11 +72,7 @@ The following cargo features are available:
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of rust 1.42.0 (2020-03-12).  However, one dependency of this
-crate (`bitflags`) require a newer version of rust, and must be manually pinned to an older version in
-order to use rust 1.42.  You can do this by running:
-
-    cargo update -p bitflags --precise 1.2.1
+This crate requires a minimum rust version of 1.48.0 (2020-11-19).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,23 +21,27 @@ process.  This is very similar to what "ps" does in its default mode:
 ```rust
 fn main() {
     let me = procfs::process::Process::myself().unwrap();
+    let me_stat = me.stat().unwrap();
     let tps = procfs::ticks_per_second().unwrap();
 
     println!("{: >5} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 
-    let tty = format!("pty/{}", me.stat.tty_nr().1);
+    let tty = format!("pty/{}", me_stat.tty_nr().1);
     for prc in procfs::process::all_processes().unwrap() {
-        if prc.stat.tty_nr == me.stat.tty_nr {
+        let prc = prc.unwrap();
+        let stat = prc.stat().unwrap();
+        if stat.tty_nr == me_stat.tty_nr {
             // total_time is in seconds
             let total_time =
-                (prc.stat.utime + prc.stat.stime) as f32 / (tps as f32);
+                (stat.utime + stat.stime) as f32 / (tps as f32);
             println!(
                 "{: >5} {: <8} {: >8} {}",
-                prc.stat.pid, tty, total_time, prc.stat.comm
+                stat.pid, tty, total_time, stat.comm
             );
         }
     }
 }
+
 ```
 
 Here's another example that shows how to get the current memory usage of the current process:
@@ -47,15 +51,17 @@ use procfs::process::Process;
 
 fn main() {
     let me = Process::myself().unwrap();
+    let me_stat = me.stat().unwrap();
     println!("PID: {}", me.pid);
 
     let page_size = procfs::page_size().unwrap() as u64;
     println!("Memory page size: {}", page_size);
 
     println!("== Data from /proc/self/stat:");
-    println!("Total virtual memory used: {} bytes", me.stat.vsize);
-    println!("Total resident set: {} pages ({} bytes)", me.stat.rss, me.stat.rss as u64 * page_size);
+    println!("Total virtual memory used: {} bytes", me_stat.vsize);
+    println!("Total resident set: {} pages ({} bytes)", me_stat.rss, me_stat.rss as u64 * page_size);
 }
+
 ```
 
 There are a few ways to get this data, so also checkout the longer

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -11,6 +11,7 @@ fn main() {
     };
     println!("{:#?}", prc);
 
-    println!("State: {:?}", prc.stat.state());
-    println!("RSS:   {} bytes", prc.stat.rss_bytes().unwrap());
+    let stat = prc.stat().unwrap();
+    println!("State: {:?}", stat.state());
+    println!("RSS:   {} bytes", stat.rss_bytes().unwrap());
 }

--- a/examples/lslocks.rs
+++ b/examples/lslocks.rs
@@ -33,7 +33,8 @@ fn main() {
         let mut found = false;
         if let Some(pid) = lock.pid {
             if let Ok(fds) = Process::new(pid).and_then(|p| p.fd()) {
-                for fd in fds {
+                for f in fds {
+                    let fd = f.unwrap();
                     if let FDTarget::Path(p) = fd.target {
                         if let Ok(stat) = rustix::fs::statat(&rustix::fs::cwd(), &p, AtFlags::empty()) {
                             if stat.st_ino as u64 == lock.inode {

--- a/examples/netstat.rs
+++ b/examples/netstat.rs
@@ -2,7 +2,7 @@
 
 extern crate procfs;
 
-use procfs::process::{FDTarget, Process};
+use procfs::process::{FDTarget, Stat};
 
 use std::collections::HashMap;
 
@@ -11,12 +11,13 @@ fn main() {
     let all_procs = procfs::process::all_processes().unwrap();
 
     // build up a map between socket inodes and processes:
-    let mut map: HashMap<u64, &Process> = HashMap::new();
-    for process in &all_procs {
-        if let Ok(fds) = process.fd() {
+    let mut map: HashMap<u64, Stat> = HashMap::new();
+    for p in all_procs {
+        let process = p.unwrap();
+        if let (Ok(stat), Ok(fds)) = (process.stat(), process.fd()) {
             for fd in fds {
-                if let FDTarget::Socket(inode) = fd.target {
-                    map.insert(inode, process);
+                if let FDTarget::Socket(inode) = fd.unwrap().target {
+                    map.insert(inode, stat.clone());
                 }
             }
         }
@@ -36,10 +37,10 @@ fn main() {
         let local_address = format!("{}", entry.local_address);
         let remote_addr = format!("{}", entry.remote_address);
         let state = format!("{:?}", entry.state);
-        if let Some(process) = map.get(&entry.inode) {
+        if let Some(stat) = map.get(&entry.inode) {
             println!(
                 "{:<26} {:<26} {:<15} {:<12} {}/{}",
-                local_address, remote_addr, state, entry.inode, process.stat.pid, process.stat.comm
+                local_address, remote_addr, state, entry.inode, stat.pid, stat.comm
             );
         } else {
             // We might not always be able to find the process assocated with this socket

--- a/examples/process_hierarchy.rs
+++ b/examples/process_hierarchy.rs
@@ -1,17 +1,30 @@
-use procfs::process::{all_processes, Process};
+use procfs::process::{all_processes, Stat};
+
+struct ProcessEntry {
+    stat: Stat,
+    cmdline: Option<Vec<String>>,
+}
 
 /// Print all processes as a tree.
 /// The tree reflects the hierarchical relationship between parent and child processes.
 fn main() {
     // Get all processes
-    let processes = match all_processes() {
+    let processes: Vec<ProcessEntry> = match all_processes() {
         Err(err) => {
             println!("Failed to read all processes: {}", err);
             return;
         }
         Ok(processes) => processes,
-    };
-
+    }
+    .filter_map(|v| {
+        v.and_then(|p| {
+            let stat = p.stat()?;
+            let cmdline = p.cmdline().ok();
+            Ok(ProcessEntry { stat, cmdline })
+        })
+        .ok()
+    })
+    .collect();
     // Iterate through all processes and start with top-level processes.
     // Those can be identified by checking if their parent PID is zero.
     for process in &processes {
@@ -26,10 +39,10 @@ fn main() {
 /// It's a depth-first tree exploration.
 ///
 /// depth: The hierarchical depth of the process
-fn print_process(process: &Process, all_processes: &[Process], depth: usize) {
-    let cmdline = match process.cmdline() {
-        Ok(cmdline) => cmdline.join(" "),
-        Err(_) => "zombie process".into(),
+fn print_process(process: &ProcessEntry, all_processes: &Vec<ProcessEntry>, depth: usize) {
+    let cmdline = match &process.cmdline {
+        Some(cmdline) => cmdline.join(" "),
+        None => "zombie process".into(),
     };
 
     // Some processes seem to have an empty cmdline.
@@ -39,13 +52,13 @@ fn print_process(process: &Process, all_processes: &[Process], depth: usize) {
 
     // 10 characters width for the pid
     let pid_length = 8;
-    let mut pid = process.pid.to_string();
+    let mut pid = process.stat.pid.to_string();
     pid.push_str(&" ".repeat(pid_length - pid.len()));
 
     let padding = " ".repeat(4 * depth);
     println!("{}{}{}", pid, padding, cmdline);
 
-    let children = get_children(process.pid, all_processes);
+    let children = get_children(process.stat.pid, all_processes);
     for child in &children {
         print_process(child, all_processes, depth + 1);
     }
@@ -53,7 +66,7 @@ fn print_process(process: &Process, all_processes: &[Process], depth: usize) {
 
 /// Get all children of a specific process, by iterating through all processes and
 /// checking their parent pid.
-pub fn get_children(pid: i32, all_processes: &[Process]) -> Vec<&Process> {
+fn get_children(pid: i32, all_processes: &Vec<ProcessEntry>) -> Vec<&ProcessEntry> {
     all_processes
         .iter()
         .filter(|process| process.stat.ppid == pid)

--- a/examples/ps.rs
+++ b/examples/ps.rs
@@ -6,17 +6,20 @@ extern crate procfs;
 /// It shows all the processes that share the same tty as our self
 
 fn main() {
-    let me = procfs::process::Process::myself().unwrap();
+    let mestat = procfs::process::Process::myself().unwrap().stat().unwrap();
     let tps = procfs::ticks_per_second().unwrap();
 
-    println!("{: >5} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
+    println!("{: >10} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 
-    let tty = format!("pty/{}", me.stat.tty_nr().1);
-    for prc in procfs::process::all_processes().unwrap() {
-        if prc.stat.tty_nr == me.stat.tty_nr {
-            // total_time is in seconds
-            let total_time = (prc.stat.utime + prc.stat.stime) as f32 / (tps as f32);
-            println!("{: >5} {: <8} {: >8} {}", prc.stat.pid, tty, total_time, prc.stat.comm);
+    let tty = format!("pty/{}", mestat.tty_nr().1);
+    for p in procfs::process::all_processes().unwrap() {
+        let prc = p.unwrap();
+        if let Ok(stat) = prc.stat() {
+            if stat.tty_nr == mestat.tty_nr {
+                // total_time is in seconds
+                let total_time = (stat.utime + stat.stime) as f32 / (tps as f32);
+                println!("{: >10} {: <8} {: >8} {}", stat.pid, tty, total_time, stat.comm);
+            }
         }
     }
 }

--- a/examples/self_memory.rs
+++ b/examples/self_memory.rs
@@ -10,14 +10,16 @@ fn main() {
     // Note: when comparing the below values to what "top" will display, note that "top" will use
     // base-2 units (kibibytes), not base-10 units (kilobytes).
 
-    println!("== Data from /proc/self/stat:");
-    println!("Total virtual memory used: {} bytes", me.stat.vsize);
-    println!(
-        "Total resident set: {} pages ({} bytes)",
-        me.stat.rss,
-        me.stat.rss as u64 * page_size
-    );
-    println!();
+    if let Ok(stat) = me.stat() {
+        println!("== Data from /proc/self/stat:");
+        println!("Total virtual memory used: {} bytes", stat.vsize);
+        println!(
+            "Total resident set: {} pages ({} bytes)",
+            stat.rss,
+            stat.rss as u64 * page_size
+        );
+        println!();
+    }
 
     if let Ok(statm) = me.statm() {
         println!("== Data from /proc/self/statm:");

--- a/examples/shm.rs
+++ b/examples/shm.rs
@@ -10,6 +10,7 @@ fn main() {
         println!("============");
 
         for prc in procfs::process::all_processes().unwrap() {
+            let prc = prc.unwrap();
             match prc.smaps() {
                 Ok(memory_maps) => {
                     for (memory_map, _memory_map_data) in &memory_maps {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,12 +492,6 @@ impl From<std::io::Error> for ProcError {
     }
 }
 
-impl From<rustix::io::Error> for ProcError {
-    fn from(io: rustix::io::Error) -> Self {
-        Into::<std::io::Error>::into(io).into()
-    }
-}
-
 impl From<&'static str> for ProcError {
     fn from(val: &'static str) -> Self {
         ProcError::Other(val.to_owned())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,7 @@
-// Don't throw clippy warnings for manual string stripping.
-// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
 #![allow(clippy::unknown_clippy_lints)]
-#![allow(clippy::manual_strip)]
+// The suggested fix with `str::parse` removes support for Rust 1.48
 #![allow(clippy::from_str_radix_10)]
-// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
-#![allow(clippy::manual_non_exhaustive)]
-// Don't throw rustc lint warnings for the deprecated name `intra_doc_link_resolution_failure`.
-// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
-#![allow(renamed_and_removed_lints)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 //! This crate provides to an interface into the linux `procfs` filesystem, usually mounted at
 //! `/proc`.
 //!
@@ -997,16 +990,16 @@ impl KernelStats {
                 total_cpu = Some(CpuTime::from_str(&line)?);
             } else if line.starts_with("cpu") {
                 cpus.push(CpuTime::from_str(&line)?);
-            } else if line.starts_with("ctxt ") {
-                ctxt = Some(from_str!(u64, &line[5..]));
-            } else if line.starts_with("btime ") {
-                btime = Some(from_str!(u64, &line[6..]));
-            } else if line.starts_with("processes ") {
-                processes = Some(from_str!(u64, &line[10..]));
-            } else if line.starts_with("procs_running ") {
-                procs_running = Some(from_str!(u32, &line[14..]));
-            } else if line.starts_with("procs_blocked ") {
-                procs_blocked = Some(from_str!(u32, &line[14..]));
+            } else if let Some(stripped) = line.strip_prefix("ctxt ") {
+                ctxt = Some(from_str!(u64, stripped));
+            } else if let Some(stripped) = line.strip_prefix("btime ") {
+                btime = Some(from_str!(u64, stripped));
+            } else if let Some(stripped) = line.strip_prefix("processes ") {
+                processes = Some(from_str!(u64, stripped));
+            } else if let Some(stripped) = line.strip_prefix("procs_running ") {
+                procs_running = Some(from_str!(u32, stripped));
+            } else if let Some(stripped) = line.strip_prefix("procs_blocked ") {
+                procs_blocked = Some(from_str!(u32, stripped));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 // Don't throw clippy warnings for manual string stripping.
-// The suggested fix with `strip_prefix` removes support for Rust 1.33 and 1.38
+// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
 #![allow(clippy::unknown_clippy_lints)]
 #![allow(clippy::manual_strip)]
 #![allow(clippy::from_str_radix_10)]
-// `#[non_exhaustive]` require Rust 1.40+ but procfs minimal Rust version is 1.34
+// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
 #![allow(clippy::manual_non_exhaustive)]
 // Don't throw rustc lint warnings for the deprecated name `intra_doc_link_resolution_failure`.
-// The suggested rename to `broken_intra_doc_links` removes support for Rust 1.33 and 1.38.
+// TODO: This is no longer needed now that the minimal Rust version is now 1.48.
 #![allow(renamed_and_removed_lints)]
 #![deny(intra_doc_link_resolution_failure)]
 //! This crate provides to an interface into the linux `procfs` filesystem, usually mounted at

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -26,11 +26,8 @@ use super::{convert_to_kibibytes, FileWrapper, ProcResult};
 /// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug, Clone)]
 #[allow(non_snake_case)]
+#[non_exhaustive]
 pub struct Meminfo {
-    // this private field prevents clients from directly constructing this object.
-    // this allows us (procfs) to add fields in a semver compatible way
-    _private: (),
-
     /// Total usable RAM (i.e., physical RAM minus a few reserved bits and the kernel binary code).
     pub mem_total: u64,
     /// The sum of [LowFree](#structfield.low_free) + [HighFree](#structfield.high_free).
@@ -319,7 +316,6 @@ impl Meminfo {
         // if there's anything still left in the map at the end, that
         // means we probably have a bug/typo, or are out-of-date
         let meminfo = Meminfo {
-            _private: (),
             mem_total: expect!(map.remove("MemTotal")),
             mem_free: expect!(map.remove("MemFree")),
             mem_available: map.remove("MemAvailable"),

--- a/src/meminfo.rs
+++ b/src/meminfo.rs
@@ -378,7 +378,7 @@ impl Meminfo {
             file_huge_pages: map.remove("FileHugePages"),
         };
 
-        assert!(!(cfg!(test) && !map.is_empty()), "meminfo map is not empty: {:#?}", map);
+        assert!(!cfg!(test) || map.is_empty(), "meminfo map is not empty: {:#?}", map);
 
         Ok(meminfo)
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -20,8 +20,7 @@
 //! # use std::collections::HashMap;
 //! let all_procs = procfs::process::all_processes().unwrap();
 //!
-//! // build up a map between socket inodes and processes:
-//! // build up a map between socket inodes and processes:
+//! // build up a map between socket inodes and process stat info:
 //! let mut map: HashMap<u64, Stat> = HashMap::new();
 //! for p in all_procs {
 //!     let process = p.unwrap();

--- a/src/net.rs
+++ b/src/net.rs
@@ -16,17 +16,19 @@
 //! > cargo run --example=netstat
 //!
 //! ```rust
-//! # use procfs::process::{Process, FDTarget};
+//! # use procfs::process::{FDTarget, Stat};
 //! # use std::collections::HashMap;
 //! let all_procs = procfs::process::all_processes().unwrap();
 //!
 //! // build up a map between socket inodes and processes:
-//! let mut map: HashMap<u64, &Process> = HashMap::new();
-//! for process in &all_procs {
-//!     if let Ok(fds) = process.fd() {
+//! // build up a map between socket inodes and processes:
+//! let mut map: HashMap<u64, Stat> = HashMap::new();
+//! for p in all_procs {
+//!     let process = p.unwrap();
+//!     if let (Ok(stat), Ok(fds)) = (process.stat(), process.fd()) {
 //!         for fd in fds {
-//!             if let FDTarget::Socket(inode) = fd.target {
-//!                 map.insert(inode, process);
+//!             if let FDTarget::Socket(inode) = fd.unwrap().target {
+//!                 map.insert(inode, stat.clone());
 //!             }
 //!         }
 //!     }
@@ -41,8 +43,8 @@
 //!     let local_address = format!("{}", entry.local_address);
 //!     let remote_addr = format!("{}", entry.remote_address);
 //!     let state = format!("{:?}", entry.state);
-//!     if let Some(process) = map.get(&entry.inode) {
-//!         println!("{:<26} {:<26} {:<15} {:<12} {}/{}", local_address, remote_addr, state, entry.inode, process.stat.pid, process.stat.comm);
+//!     if let Some(stat) = map.get(&entry.inode) {
+//!         println!("{:<26} {:<26} {:<15} {:<12} {}/{}", local_address, remote_addr, state, entry.inode, stat.pid, stat.comm);
 //!     } else {
 //!         // We might not always be able to find the process associated with this socket
 //!         println!("{:<26} {:<26} {:<15} {:<12} -", local_address, remote_addr, state, entry.inode);

--- a/src/process/limit.rs
+++ b/src/process/limit.rs
@@ -7,8 +7,7 @@ use std::str::FromStr;
 impl crate::process::Process {
     /// Return the limits for this process
     pub fn limits(&self) -> ProcResult<Limits> {
-        let path = self.root.join("limits");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "limits")?;
         Limits::from_reader(file)
     }
 }

--- a/src/process/limit.rs
+++ b/src/process/limit.rs
@@ -4,8 +4,6 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
 use std::str::FromStr;
 
-use libc::rlim_t;
-
 impl crate::process::Process {
     /// Return the limits for this process
     pub fn limits(&self) -> ProcResult<Limits> {
@@ -188,15 +186,15 @@ impl Limit {
 #[derive(Debug, Copy, Clone)]
 pub enum LimitValue {
     Unlimited,
-    Value(rlim_t),
+    Value(u64),
 }
 
 impl LimitValue {
     #[cfg(test)]
-    pub(crate) fn as_rlim_t(&self) -> libc::rlim_t {
+    pub(crate) fn as_limit(&self) -> Option<u64> {
         match self {
-            LimitValue::Unlimited => libc::RLIM_INFINITY,
-            LimitValue::Value(v) => *v,
+            LimitValue::Unlimited => None,
+            LimitValue::Value(v) => Some(*v),
         }
     }
 }
@@ -207,7 +205,7 @@ impl FromStr for LimitValue {
         if s == "unlimited" {
             Ok(LimitValue::Unlimited)
         } else {
-            Ok(LimitValue::Value(from_str!(rlim_t, s)))
+            Ok(LimitValue::Value(from_str!(u64, s)))
         }
     }
 }
@@ -215,6 +213,7 @@ impl FromStr for LimitValue {
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use rustix::process::Resource;
 
     #[test]
     fn test_limits() {
@@ -222,89 +221,84 @@ mod tests {
         let limits = me.limits().unwrap();
         println!("{:#?}", limits);
 
-        let mut libc_lim = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
-        };
-
         // Max cpu time
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_CPU, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_cpu_time.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_cpu_time.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Cpu);
+        assert_eq!(lim.current, limits.max_cpu_time.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_cpu_time.hard_limit.as_limit());
 
         // Max file size
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_FSIZE, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_file_size.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_file_size.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Fsize);
+        assert_eq!(lim.current, limits.max_file_size.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_file_size.hard_limit.as_limit());
 
         // Max data size
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_DATA, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_data_size.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_data_size.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Data);
+        assert_eq!(lim.current, limits.max_data_size.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_data_size.hard_limit.as_limit());
 
         // Max stack size
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_STACK, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_stack_size.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_stack_size.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Stack);
+        assert_eq!(lim.current, limits.max_stack_size.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_stack_size.hard_limit.as_limit());
 
         // Max core file size
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_CORE, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_core_file_size.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_core_file_size.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Core);
+        assert_eq!(lim.current, limits.max_core_file_size.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_core_file_size.hard_limit.as_limit());
 
         // Max resident set
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_RSS, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_resident_set.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_resident_set.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Rss);
+        assert_eq!(lim.current, limits.max_resident_set.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_resident_set.hard_limit.as_limit());
 
         // Max processes
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_NPROC, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_processes.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_processes.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Nproc);
+        assert_eq!(lim.current, limits.max_processes.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_processes.hard_limit.as_limit());
 
         // Max open files
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_open_files.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_open_files.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Nofile);
+        assert_eq!(lim.current, limits.max_open_files.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_open_files.hard_limit.as_limit());
 
         // Max locked memory
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_locked_memory.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_locked_memory.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Memlock);
+        assert_eq!(lim.current, limits.max_locked_memory.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_locked_memory.hard_limit.as_limit());
 
         // Max address space
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_AS, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_address_space.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_address_space.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::As);
+        assert_eq!(lim.current, limits.max_address_space.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_address_space.hard_limit.as_limit());
 
         // Max file locks
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_LOCKS, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_file_locks.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_file_locks.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Locks);
+        assert_eq!(lim.current, limits.max_file_locks.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_file_locks.hard_limit.as_limit());
 
         // Max pending signals
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_SIGPENDING, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_pending_signals.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_pending_signals.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Sigpending);
+        assert_eq!(lim.current, limits.max_pending_signals.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_pending_signals.hard_limit.as_limit());
 
         // Max msgqueue size
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_MSGQUEUE, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_msgqueue_size.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_msgqueue_size.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Msgqueue);
+        assert_eq!(lim.current, limits.max_msgqueue_size.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_msgqueue_size.hard_limit.as_limit());
 
         // Max nice priority
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_NICE, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_nice_priority.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_nice_priority.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Nice);
+        assert_eq!(lim.current, limits.max_nice_priority.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_nice_priority.hard_limit.as_limit());
 
         // Max realtime priority
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_RTPRIO, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_realtime_priority.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_realtime_priority.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Rtprio);
+        assert_eq!(lim.current, limits.max_realtime_priority.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_realtime_priority.hard_limit.as_limit());
 
         // Max realtime timeout
-        assert_eq!(unsafe { libc::getrlimit(libc::RLIMIT_RTTIME, &mut libc_lim) }, 0);
-        assert_eq!(libc_lim.rlim_cur, limits.max_realtime_timeout.soft_limit.as_rlim_t());
-        assert_eq!(libc_lim.rlim_max, limits.max_realtime_timeout.hard_limit.as_rlim_t());
+        let lim = rustix::process::getrlimit(Resource::Rttime);
+        assert_eq!(lim.current, limits.max_realtime_timeout.soft_limit.as_limit());
+        assert_eq!(lim.maximum, limits.max_realtime_timeout.hard_limit.as_limit());
     }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -698,7 +698,7 @@ impl FDInfo {
     /// Gets a file descriptor from a directory fd and a path relative to it.
     ///
     /// `base` is the path to the directory fd, and is used for error messages.
-    pub fn from_process_at<P: AsRef<Path>, Q: AsRef<Path>>(
+    fn from_process_at<P: AsRef<Path>, Q: AsRef<Path>>(
         base: P,
         dirfd: BorrowedFd,
         path: Q,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -596,7 +596,7 @@ impl Io {
             cancelled_write_bytes: expect!(map.remove("cancelled_write_bytes")),
         };
 
-        assert!(!(cfg!(test) && !map.is_empty()), "io map is not empty: {:#?}", map);
+        assert!(!cfg!(test) || map.is_empty(), "io map is not empty: {:#?}", map);
 
         Ok(io)
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -180,10 +180,15 @@ bitflags! {
 
 bitflags! {
     /// The mode (read/write permissions) for an open file descriptor
-    pub struct FDPermissions: RawMode {
-        const READ = Mode::RUSR.bits();
-        const WRITE = Mode::WUSR.bits();
-        const EXECUTE = Mode::XUSR.bits();
+    ///
+    /// This is represented as `u16` since the values of these bits are
+    /// [documented] to be within the `u16` range.
+    ///
+    /// [documented]: https://man7.org/linux/man-pages/man2/chmod.2.html#DESCRIPTION
+    pub struct FDPermissions: u16 {
+        const READ = Mode::RUSR.bits() as u16;
+        const WRITE = Mode::WUSR.bits() as u16;
+        const EXECUTE = Mode::XUSR.bits() as u16;
     }
 }
 
@@ -672,7 +677,7 @@ pub struct FDInfo {
     ///
     /// **Note**: this field is only the owner read/write/execute bits.  All the other bits
     /// (include filetype bits) are masked out.  See also the `mode()` method.
-    pub mode: RawMode,
+    pub mode: u16,
     pub target: FDTarget,
 }
 
@@ -690,7 +695,7 @@ impl FDInfo {
         let link_os: &OsStr = link.as_ref();
         Ok(Self {
             fd: raw_fd,
-            mode: (md.mode() as RawMode) & Mode::RWXU.bits(),
+            mode: ((md.mode() as RawMode) & Mode::RWXU.bits()) as u16,
             target: expect!(FDTarget::from_str(expect!(link_os.to_str()))),
         })
     }
@@ -725,7 +730,7 @@ impl FDInfo {
         let target = FDTarget::from_str(link_os.as_ref())?;
         Ok(FDInfo {
             fd,
-            mode: md.st_mode & Mode::RWXU.bits(),
+            mode: (md.st_mode & Mode::RWXU.bits()) as u16,
             target,
         })
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -18,20 +18,23 @@
 //!
 //! ```rust
 //! let me = procfs::process::Process::myself().unwrap();
+//! let me_stat = me.stat().unwrap();
 //! let tps = procfs::ticks_per_second().unwrap();
 //!
-//! println!("{: >5} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
+//! println!("{: >10} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 //!
-//! let tty = format!("pty/{}", me.stat.tty_nr().1);
+//! let tty = format!("pty/{}", me_stat.tty_nr().1);
 //! for prc in procfs::process::all_processes().unwrap() {
-//!     if prc.stat.tty_nr == me.stat.tty_nr {
-//!         // total_time is in seconds
-//!         let total_time =
-//!             (prc.stat.utime + prc.stat.stime) as f32 / (tps as f32);
-//!         println!(
-//!             "{: >5} {: <8} {: >8} {}",
-//!             prc.stat.pid, tty, total_time, prc.stat.comm
-//!         );
+//!     if let Ok(stat) = prc.unwrap().stat() {
+//!         if stat.tty_nr == me_stat.tty_nr {
+//!             // total_time is in seconds
+//!             let total_time =
+//!                 (stat.utime + stat.stime) as f32 / (tps as f32);
+//!             println!(
+//!                 "{: >10} {: <8} {: >8} {}",
+//!                 stat.pid, tty, total_time, stat.comm
+//!             );
+//!         }
 //!     }
 //! }
 //! ```
@@ -45,26 +48,26 @@
 //! ```rust
 //! # use procfs::process::Process;
 //! let me = Process::myself().unwrap();
+//! let me_stat = me.stat().unwrap();
 //! let page_size = procfs::page_size().unwrap() as u64;
 //!
 //! println!("== Data from /proc/self/stat:");
-//! println!("Total virtual memory used: {} bytes", me.stat.vsize);
-//! println!("Total resident set: {} pages ({} bytes)", me.stat.rss, me.stat.rss as u64 * page_size);
+//! println!("Total virtual memory used: {} bytes", me_stat.vsize);
+//! println!("Total resident set: {} pages ({} bytes)", me_stat.rss, me_stat.rss as u64 * page_size);
 //! ```
 
 use super::*;
 use crate::from_iter;
 
-use rustix::fs::{Mode, RawMode};
+use rustix::fd::{AsFd, BorrowedFd, FromFd, IntoFd, RawFd};
+use rustix::fs::{AtFlags, Mode, OFlags, RawMode};
+use rustix::io::OwnedFd;
 use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::fs;
 use std::fs::read_link;
 use std::io::{self, Read};
-#[cfg(target_os = "android")]
-use std::os::android::fs::MetadataExt;
-#[cfg(all(unix, not(target_os = "android")))]
-use std::os::linux::fs::MetadataExt;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -88,18 +91,6 @@ pub use schedstat::*;
 
 mod task;
 pub use task::*;
-
-// provide a type-compatible st_uid for windows
-#[cfg(windows)]
-trait FakeMedatadataExt {
-    fn st_uid(&self) -> u32;
-}
-#[cfg(windows)]
-impl FakeMedatadataExt for std::fs::Metadata {
-    fn st_uid(&self) -> u32 {
-        panic!()
-    }
-}
 
 bitflags! {
     /// Kernel flags for a process
@@ -676,7 +667,7 @@ impl FromStr for FDTarget {
 #[derive(Clone)]
 pub struct FDInfo {
     /// The file descriptor
-    pub fd: u32,
+    pub fd: i32,
     /// The permission bits for this FD
     ///
     /// **Note**: this field is only the owner read/write/execute bits.  All the other bits
@@ -698,9 +689,43 @@ impl FDInfo {
         let md = wrap_io_error!(path, path.symlink_metadata())?;
         let link_os: &OsStr = link.as_ref();
         Ok(Self {
-            fd: raw_fd as u32,
-            mode: (md.st_mode() as RawMode) & Mode::RWXU.bits(),
+            fd: raw_fd,
+            mode: (md.mode() as RawMode) & Mode::RWXU.bits(),
             target: expect!(FDTarget::from_str(expect!(link_os.to_str()))),
+        })
+    }
+
+    /// Gets a file descriptor from a directory fd and a path relative to it.
+    ///
+    /// `base` is the path to the directory fd, and is used for error messages.
+    pub fn from_process_at<P: AsRef<Path>, Q: AsRef<Path>>(
+        base: P,
+        dirfd: BorrowedFd,
+        path: Q,
+        fd: i32,
+    ) -> ProcResult<Self> {
+        let p = path.as_ref();
+        let root = base.as_ref().join(p);
+        let file = wrap_io_error!(
+            root,
+            rustix::fs::openat(
+                dirfd,
+                p,
+                OFlags::NOFOLLOW | OFlags::PATH | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )
+        .map(|fdfd| File::from_fd(fdfd.into()))?;
+        let fdfd = file.as_fd();
+        let link = rustix::fs::readlinkat(fdfd, "", Vec::new())?;
+        let md = rustix::fs::statat(fdfd, "", AtFlags::SYMLINK_NOFOLLOW | AtFlags::EMPTY_PATH)?;
+
+        let link_os = link.to_string_lossy();
+        let target = FDTarget::from_str(link_os.as_ref())?;
+        Ok(FDInfo {
+            fd,
+            mode: md.st_mode & Mode::RWXU.bits(),
+            target,
         })
     }
 
@@ -721,19 +746,10 @@ impl std::fmt::Debug for FDInfo {
 }
 
 /// Represents a process in `/proc/<pid>`.
-///
-/// The `stat` structure is pre-populated because it's useful info, but other data is loaded on
-/// demand (and so might fail, if the process no longer exist).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Process {
-    /// The process ID
-    ///
-    /// (same as the `Stat.pid` field).
+    pub fd: OwnedFd,
     pub pid: i32,
-    /// Process status, based on the `/proc/<pid>/stat` file.
-    pub stat: Stat,
-    /// The user id of the owner of this process
-    pub owner: u32,
     pub(crate) root: PathBuf,
 }
 
@@ -742,22 +758,46 @@ impl Process {
     ///
     /// This can fail if the process doesn't exist, or if you don't have permission to access it.
     pub fn new(pid: i32) -> ProcResult<Process> {
-        let root = PathBuf::from("/proc").join(format!("{}", pid));
+        let root = PathBuf::from("/proc").join(pid.to_string());
         Self::new_with_root(root)
     }
 
     /// Returns a `Process` based on a specified `/proc/<pid>` path.
     pub fn new_with_root(root: PathBuf) -> ProcResult<Process> {
-        let path = root.join("stat");
-        let stat = Stat::from_reader(FileWrapper::open(&path)?)?;
+        let file = wrap_io_error!(
+            root,
+            rustix::fs::openat(
+                &rustix::fs::cwd(),
+                &root,
+                OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )
+        .map(|fd| File::from_fd(fd.into()))?;
 
-        let md = std::fs::metadata(&root)?;
+        let pidres = root
+            .as_path()
+            .components()
+            .last()
+            .and_then(|c| match c {
+                std::path::Component::Normal(s) => Some(s),
+                _ => None,
+            })
+            .and_then(|s| s.to_string_lossy().parse::<i32>().ok())
+            .or_else(|| {
+                rustix::fs::readlinkat(&rustix::fs::cwd(), &root, Vec::new())
+                    .ok()
+                    .and_then(|s| s.to_string_lossy().parse::<i32>().ok())
+            });
+        let pid = match pidres {
+            Some(pid) => pid,
+            None => return Err(ProcError::NotFound(Some(root))),
+        };
 
         Ok(Process {
-            pid: stat.pid,
+            fd: file.into_fd().into(),
+            pid,
             root,
-            stat,
-            owner: md.st_uid(),
         })
     }
 
@@ -774,7 +814,7 @@ impl Process {
     ///
     pub fn cmdline(&self) -> ProcResult<Vec<String>> {
         let mut buf = String::new();
-        let mut f = FileWrapper::open(self.root.join("cmdline"))?;
+        let mut f = FileWrapper::open_at(&self.root, &self.fd, "cmdline")?;
         f.read_to_string(&mut buf)?;
         Ok(buf
             .split('\0')
@@ -782,26 +822,19 @@ impl Process {
             .collect())
     }
 
-    /// Returns the process ID for this process.
+    /// Returns the process ID for this process, if the process was created from an ID. Otherwise
+    /// use stat().pid.
     pub fn pid(&self) -> i32 {
-        self.stat.pid
+        self.pid
     }
 
     /// Is this process still alive?
     pub fn is_alive(&self) -> bool {
-        match Process::new(self.pid()) {
-            Ok(prc) => {
-                // assume that the command line, uid and starttime don't change during a processes lifetime
-                // additionally, do not consider defunct processes as "alive"
-                // i.e. if they are different, a new process has the same PID as `self` and so `self` is not considered alive
-                prc.stat.comm == self.stat.comm
-                    && prc.owner == self.owner
-                    && prc.stat.starttime == self.stat.starttime
-                    && prc.stat.state().map(|s| s != ProcState::Zombie).unwrap_or(false)
-                    && self.stat.state().map(|s| s != ProcState::Zombie).unwrap_or(false)
-            }
-            _ => false,
-        }
+        rustix::fs::statat(&self.fd, "stat", AtFlags::empty()).is_ok()
+    }
+
+    pub fn metadata(&self) -> ProcResult<rustix::fs::Stat> {
+        Ok(rustix::fs::fstat(&self.fd)?)
     }
 
     /// Retrieves current working directory of the process by dereferencing `/proc/<pid>/cwd` symbolic link.
@@ -817,7 +850,13 @@ impl Process {
     /// * permission to dereference or read this symbolic link is governed by a
     ///   `ptrace(2)` access mode `PTRACE_MODE_READ_FSCREDS` check
     pub fn cwd(&self) -> ProcResult<PathBuf> {
-        Ok(std::fs::read_link(self.root.join("cwd"))?)
+        Ok(PathBuf::from(OsString::from_vec(
+            wrap_io_error!(
+                self.root.join("cwd"),
+                rustix::fs::readlinkat(&self.fd, "cwd", Vec::new())
+            )?
+            .into_bytes(),
+        )))
     }
 
     /// Retrieves current root directory of the process by dereferencing `/proc/<pid>/root` symbolic link.
@@ -833,7 +872,13 @@ impl Process {
     /// * permission to dereference or read this symbolic link is governed by a
     ///   `ptrace(2)` access mode `PTRACE_MODE_READ_FSCREDS` check
     pub fn root(&self) -> ProcResult<PathBuf> {
-        Ok(std::fs::read_link(self.root.join("root"))?)
+        Ok(PathBuf::from(OsString::from_vec(
+            wrap_io_error!(
+                self.root.join("root"),
+                rustix::fs::readlinkat(&self.fd, "root", Vec::new())
+            )?
+            .into_bytes(),
+        )))
     }
 
     /// Gets the current environment for the process.  This is done by reading the
@@ -843,7 +888,7 @@ impl Process {
 
         let mut map = HashMap::new();
 
-        let mut file = FileWrapper::open(self.root.join("environ"))?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "environ")?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
 
@@ -872,30 +917,34 @@ impl Process {
     /// * permission to dereference or read this symbolic link is governed by a
     ///   `ptrace(2)` access mode `PTRACE_MODE_READ_FSCREDS` check
     pub fn exe(&self) -> ProcResult<PathBuf> {
-        Ok(std::fs::read_link(self.root.join("exe"))?)
+        Ok(PathBuf::from(OsString::from_vec(
+            wrap_io_error!(
+                self.root.join("exe"),
+                rustix::fs::readlinkat(&self.fd, "exe", Vec::new())
+            )?
+            .into_bytes(),
+        )))
     }
 
     /// Return the Io stats for this process, based on the `/proc/pid/io` file.
     ///
     /// (since kernel 2.6.20)
     pub fn io(&self) -> ProcResult<Io> {
-        let path = self.root.join("io");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "io")?;
         Io::from_reader(file)
     }
 
     /// Return a list of the currently mapped memory regions and their access permissions, based on
     /// the `/proc/pid/maps` file.
     pub fn maps(&self) -> ProcResult<Vec<MemoryMap>> {
-        let path = self.root.join("maps");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "maps")?;
 
         let reader = BufReader::new(file);
 
         let mut vec = Vec::new();
 
         for line in reader.lines() {
-            let line = line.map_err(|_| ProcError::Incomplete(Some(path.clone())))?;
+            let line = line.map_err(|_| ProcError::Incomplete(Some(self.root.join("maps"))))?;
             vec.push(MemoryMap::from_line(&line)?);
         }
 
@@ -907,8 +956,7 @@ impl Process {
     ///
     /// (since Linux 2.6.14 and requires CONFIG_PROG_PAGE_MONITOR)
     pub fn smaps(&self) -> ProcResult<Vec<(MemoryMap, MemoryMapData)>> {
-        let path = self.root.join("smaps");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "smaps")?;
 
         let reader = BufReader::new(file);
 
@@ -917,7 +965,7 @@ impl Process {
         let mut current_mapping = MemoryMap::new();
         let mut current_data = Default::default();
         for line in reader.lines() {
-            let line = line.map_err(|_| ProcError::Incomplete(Some(path.clone())))?;
+            let line = line.map_err(|_| ProcError::Incomplete(Some(self.root.join("smaps"))))?;
 
             if let Ok(mapping) = MemoryMap::from_line(&line) {
                 vec.push((current_mapping, current_data));
@@ -971,33 +1019,40 @@ impl Process {
 
     /// Gets the number of open file descriptors for a process
     pub fn fd_count(&self) -> ProcResult<usize> {
-        let path = self.root.join("fd");
-
-        Ok(wrap_io_error!(path, path.read_dir())?.count())
+        let fds = wrap_io_error!(
+            self.root.join("fd"),
+            rustix::fs::openat(
+                &self.fd,
+                "fd",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )?;
+        let fds = wrap_io_error!(self.root.join("fd"), rustix::fs::Dir::from(fds))?;
+        Ok(fds.count())
     }
 
-    /// Gets a list of open file descriptors for a process
-    pub fn fd(&self) -> ProcResult<Vec<FDInfo>> {
-        let mut vec = Vec::new();
+    /// Gets a iterator of open file descriptors for a process
+    pub fn fd(&self) -> ProcResult<FDsIter> {
+        let dir = wrap_io_error!(
+            self.root.join("fd"),
+            rustix::fs::openat(
+                &self.fd,
+                "fd",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )?;
+        let dir = wrap_io_error!(self.root.join("fd"), rustix::fs::Dir::from(dir))?;
+        Ok(FDsIter {
+            inner: dir,
+            root: self.root.clone(),
+        })
+    }
 
-        let path = self.root.join("fd");
-
-        for dir in wrap_io_error!(path, path.read_dir())? {
-            let entry = dir?;
-            let file_name = entry.file_name();
-            let fd = from_str!(u32, expect!(file_name.to_str()), 10);
-            //  note: the link might have disappeared between the time we got the directory listing
-            //  and now.  So if the read_link or metadata fails, that's OK
-            if let (Ok(link), Ok(md)) = (read_link(entry.path()), entry.metadata()) {
-                let link_os: &OsStr = link.as_ref();
-                vec.push(FDInfo {
-                    fd,
-                    mode: (md.st_mode() as RawMode) & Mode::RWXU.bits(),
-                    target: expect!(FDTarget::from_str(expect!(link_os.to_str()))),
-                });
-            }
-        }
-        Ok(vec)
+    pub fn fd_from_fd(&self, fd: i32) -> ProcResult<FDInfo> {
+        let path = PathBuf::from("fd").join(fd.to_string());
+        FDInfo::from_process_at(&self.root, self.fd.as_fd(), path, fd)
     }
 
     /// Lists which memory segments are written to the core dump in the event that a core dump is performed.
@@ -1009,14 +1064,13 @@ impl Process {
     /// This function will return `Err(ProcError::NotFound)` if the `coredump_filter` file can't be
     /// found.  If it returns `Ok(None)` then the process has no coredump_filter
     pub fn coredump_filter(&self) -> ProcResult<Option<CoredumpFlags>> {
-        let mut file = FileWrapper::open(self.root.join("coredump_filter"))?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "coredump_filter")?;
         let mut s = String::new();
         file.read_to_string(&mut s)?;
         if s.trim().is_empty() {
             return Ok(None);
         }
-        let flags = from_str!(u32, &s.trim(), 16, pid:self.stat.pid);
-
+        let flags = from_str!(u32, &s.trim(), 16, pid: self.pid);
         Ok(Some(expect!(CoredumpFlags::from_bits(flags))))
     }
 
@@ -1025,7 +1079,7 @@ impl Process {
     /// (since Linux 2.6.38 and requires CONFIG_SCHED_AUTOGROUP)
     pub fn autogroup(&self) -> ProcResult<String> {
         let mut s = String::new();
-        let mut file = FileWrapper::open(self.root.join("autogroup"))?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "autogroup")?;
         file.read_to_string(&mut s)?;
         Ok(s)
     }
@@ -1036,7 +1090,7 @@ impl Process {
     pub fn auxv(&self) -> ProcResult<HashMap<u32, u32>> {
         use byteorder::{NativeEndian, ReadBytesExt};
 
-        let mut file = FileWrapper::open(self.root.join("auxv"))?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "auxv")?;
         let mut map = HashMap::new();
 
         let mut buf = Vec::new();
@@ -1065,15 +1119,14 @@ impl Process {
     /// (since Linux 2.6.0)
     pub fn wchan(&self) -> ProcResult<String> {
         let mut s = String::new();
-        let mut file = FileWrapper::open(self.root.join("wchan"))?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "wchan")?;
         file.read_to_string(&mut s)?;
         Ok(s)
     }
 
     /// Return the `Status` for this process, based on the `/proc/[pid]/status` file.
     pub fn status(&self) -> ProcResult<Status> {
-        let path = self.root.join("status");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "status")?;
         Status::from_reader(file)
     }
 
@@ -1082,16 +1135,15 @@ impl Process {
     /// Note that this data comes pre-loaded in the `stat` field.  This method is useful when you
     /// get the latest status data (since some of it changes while the program is running)
     pub fn stat(&self) -> ProcResult<Stat> {
-        let path = self.root.join("stat");
-        let stat = Stat::from_reader(FileWrapper::open(&path)?)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "stat")?;
+        let stat = Stat::from_reader(file)?;
         Ok(stat)
     }
 
     /// Gets the process' login uid. May not be available.
     pub fn loginuid(&self) -> ProcResult<u32> {
         let mut uid = String::new();
-        let path = self.root.join("loginuid");
-        let mut file = FileWrapper::open(&path)?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "loginuid")?;
         file.read_to_string(&mut uid)?;
         Status::parse_uid_gid(&uid, 0)
     }
@@ -1104,8 +1156,7 @@ impl Process {
     ///
     /// (Since linux 2.6.11)
     pub fn oom_score(&self) -> ProcResult<u32> {
-        let path = self.root.join("oom_score");
-        let mut file = FileWrapper::open(&path)?;
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "oom_score")?;
         let mut oom = String::new();
         file.read_to_string(&mut oom)?;
         Ok(from_str!(u32, oom.trim()))
@@ -1115,22 +1166,26 @@ impl Process {
     ///
     /// Much of this data is the same as the data from `stat()` and `status()`
     pub fn statm(&self) -> ProcResult<StatM> {
-        let path = self.root.join("statm");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "statm")?;
         StatM::from_reader(file)
     }
 
     /// Return a task for the main thread of this process
     pub fn task_main_thread(&self) -> ProcResult<Task> {
-        Task::new(self.pid, self.pid)
+        self.task_from_tid(self.pid)
+    }
+
+    /// Return a task for the main thread of this process
+    pub fn task_from_tid(&self, tid: i32) -> ProcResult<Task> {
+        let path = PathBuf::from("task").join(tid.to_string());
+        Task::from_process_at(&self.root, self.fd.as_fd(), path, self.pid, tid)
     }
 
     /// Return the `Schedstat` for this process, based on the `/proc/<pid>/schedstat` file.
     ///
     /// (Requires CONFIG_SCHED_INFO)
     pub fn schedstat(&self) -> ProcResult<Schedstat> {
-        let path = self.root.join("schedstat");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "schedstat")?;
         Schedstat::from_reader(file)
     }
 
@@ -1240,10 +1295,48 @@ impl Process {
     /// # }
     /// ```
     pub fn tasks(&self) -> ProcResult<TasksIter> {
+        let dir = wrap_io_error!(
+            self.root.join("task"),
+            rustix::fs::openat(
+                &self.fd,
+                "task",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )?;
+        let dir = wrap_io_error!(self.root.join("task"), rustix::fs::Dir::from(dir))?;
         Ok(TasksIter {
             pid: self.pid,
-            inner: fs::read_dir(self.root.join("task"))?,
+            inner: dir,
+            root: self.root.clone(),
         })
+    }
+}
+
+/// The result of [`Process::fd`], iterates over all fds in a process
+#[derive(Debug)]
+pub struct FDsIter {
+    inner: rustix::fs::Dir,
+    root: PathBuf,
+}
+
+impl std::iter::Iterator for FDsIter {
+    type Item = ProcResult<FDInfo>;
+    fn next(&mut self) -> Option<ProcResult<FDInfo>> {
+        loop {
+            match self.inner.next() {
+                Some(Ok(entry)) => {
+                    let name = entry.file_name().to_string_lossy();
+                    if let Ok(fd) = RawFd::from_str(&name) {
+                        if let Ok(info) = FDInfo::from_process_at(&self.root, self.inner.as_fd(), name.as_ref(), fd) {
+                            break Some(Ok(info));
+                        }
+                    }
+                }
+                Some(Err(e)) => break Some(Err(e.into())),
+                None => break None,
+            }
+        }
     }
 }
 
@@ -1251,44 +1344,71 @@ impl Process {
 #[derive(Debug)]
 pub struct TasksIter {
     pid: i32,
-    inner: fs::ReadDir,
+    inner: rustix::fs::Dir,
+    root: PathBuf,
 }
 
 impl std::iter::Iterator for TasksIter {
     type Item = ProcResult<Task>;
     fn next(&mut self) -> Option<ProcResult<Task>> {
-        match self.inner.next() {
-            Some(Ok(tp)) => Some(Task::from_rel_path(self.pid, &tp.path())),
-            Some(Err(e)) => Some(Err(ProcError::Io(e, None))),
-            None => None,
-        }
-    }
-}
-
-/// Return a list of all processes
-///
-/// If a process can't be constructed for some reason, it won't be returned in the list.
-pub fn all_processes() -> ProcResult<Vec<Process>> {
-    all_processes_with_root("/proc")
-}
-
-/// Return a list of all processes based on a specified `/proc` path
-///
-/// If a process can't be constructed for some reason, it won't be returned in the list.
-pub fn all_processes_with_root(root: impl AsRef<Path>) -> ProcResult<Vec<Process>> {
-    let mut v = Vec::new();
-    let root = root.as_ref();
-    for entry in expect!(std::fs::read_dir(root), format!("No {} directory", root.display())).flatten() {
-        if i32::from_str(&entry.file_name().to_string_lossy()).is_ok() {
-            match Process::new_with_root(entry.path()) {
-                Ok(prc) => v.push(prc),
-                Err(ProcError::InternalError(e)) => return Err(ProcError::InternalError(e)),
-                _ => {}
+        loop {
+            match self.inner.next() {
+                Some(Ok(tp)) => {
+                    if let Ok(tid) = i32::from_str(&tp.file_name().to_string_lossy()) {
+                        if let Ok(task) =
+                            Task::from_process_at(&self.root, self.inner.as_fd(), tid.to_string(), self.pid, tid)
+                        {
+                            break Some(Ok(task));
+                        }
+                    }
+                }
+                Some(Err(e)) => break Some(Err(e.into())),
+                None => break None,
             }
         }
     }
+}
 
-    Ok(v)
+/// Return a iterator of all processes
+///
+/// If a process can't be constructed for some reason, it won't be returned in the iterator.
+pub fn all_processes() -> ProcResult<ProcessesIter> {
+    let root = PathBuf::from("/proc");
+    let dir = wrap_io_error!(
+        root,
+        rustix::fs::openat(
+            &rustix::fs::cwd(),
+            &root,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty()
+        )
+    )?;
+    let dir = wrap_io_error!(root, rustix::fs::Dir::from(dir))?;
+    Ok(ProcessesIter { inner: dir })
+}
+
+#[derive(Debug)]
+pub struct ProcessesIter {
+    inner: rustix::fs::Dir,
+}
+
+impl std::iter::Iterator for ProcessesIter {
+    type Item = ProcResult<Process>;
+    fn next(&mut self) -> Option<ProcResult<Process>> {
+        loop {
+            match self.inner.next() {
+                Some(Ok(entry)) => {
+                    if let Ok(pid) = i32::from_str(&entry.file_name().to_string_lossy()) {
+                        if let Ok(proc) = Process::new(pid) {
+                            break Some(Ok(proc));
+                        }
+                    }
+                }
+                Some(Err(e)) => break Some(Err(e.into())),
+                None => break None,
+            }
+        }
+    }
 }
 
 /// Provides information about memory usage, measured in pages.

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -748,7 +748,7 @@ impl std::fmt::Debug for FDInfo {
 /// Represents a process in `/proc/<pid>`.
 #[derive(Debug)]
 pub struct Process {
-    pub fd: OwnedFd,
+    fd: OwnedFd,
     pub pid: i32,
     pub(crate) root: PathBuf,
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -717,8 +717,9 @@ impl FDInfo {
         )
         .map(|fdfd| File::from_fd(fdfd.into()))?;
         let fdfd = file.as_fd();
-        let link = rustix::fs::readlinkat(fdfd, "", Vec::new())?;
-        let md = rustix::fs::statat(fdfd, "", AtFlags::SYMLINK_NOFOLLOW | AtFlags::EMPTY_PATH)?;
+        let link = rustix::fs::readlinkat(fdfd, "", Vec::new()).map_err(io::Error::from)?;
+        let md =
+            rustix::fs::statat(fdfd, "", AtFlags::SYMLINK_NOFOLLOW | AtFlags::EMPTY_PATH).map_err(io::Error::from)?;
 
         let link_os = link.to_string_lossy();
         let target = FDTarget::from_str(link_os.as_ref())?;
@@ -839,7 +840,7 @@ impl Process {
     }
 
     fn metadata(&self) -> ProcResult<rustix::fs::Stat> {
-        Ok(rustix::fs::fstat(&self.fd)?)
+        Ok(rustix::fs::fstat(&self.fd).map_err(io::Error::from)?)
     }
 
     /// Retrieves current working directory of the process by dereferencing `/proc/<pid>/cwd` symbolic link.
@@ -1338,7 +1339,7 @@ impl std::iter::Iterator for FDsIter {
                         }
                     }
                 }
-                Some(Err(e)) => break Some(Err(e.into())),
+                Some(Err(e)) => break Some(Err(io::Error::from(e).into())),
                 None => break None,
             }
         }
@@ -1367,7 +1368,7 @@ impl std::iter::Iterator for TasksIter {
                         }
                     }
                 }
-                Some(Err(e)) => break Some(Err(e.into())),
+                Some(Err(e)) => break Some(Err(io::Error::from(e).into())),
                 None => break None,
             }
         }
@@ -1409,7 +1410,7 @@ impl std::iter::Iterator for ProcessesIter {
                         }
                     }
                 }
-                Some(Err(e)) => break Some(Err(e.into())),
+                Some(Err(e)) => break Some(Err(io::Error::from(e).into())),
                 None => break None,
             }
         }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -833,7 +833,12 @@ impl Process {
         rustix::fs::statat(&self.fd, "stat", AtFlags::empty()).is_ok()
     }
 
-    pub fn metadata(&self) -> ProcResult<rustix::fs::Stat> {
+    /// What user owns this process?
+    pub fn uid(&self) -> ProcResult<u32> {
+        Ok(self.metadata()?.st_uid)
+    }
+
+    fn metadata(&self) -> ProcResult<rustix::fs::Stat> {
         Ok(rustix::fs::fstat(&self.fd)?)
     }
 

--- a/src/process/mount.rs
+++ b/src/process/mount.rs
@@ -314,18 +314,18 @@ impl MountNFSStatistics {
                 break;
             }
             if !parsing_per_op {
-                if line.starts_with("opts:") {
-                    opts = Some(line[5..].trim().split(',').map(|s| s.to_string()).collect());
-                } else if line.starts_with("age:") {
-                    age = Some(Duration::from_secs(from_str!(u64, &line[4..].trim())));
-                } else if line.starts_with("caps:") {
-                    caps = Some(line[5..].trim().split(',').map(|s| s.to_string()).collect());
-                } else if line.starts_with("sec:") {
-                    sec = Some(line[4..].trim().split(',').map(|s| s.to_string()).collect());
-                } else if line.starts_with("bytes:") {
-                    bytes = Some(NFSByteCounter::from_str(line[6..].trim())?);
-                } else if line.starts_with("events:") {
-                    events = Some(NFSEventCounter::from_str(line[7..].trim())?);
+                if let Some(stripped) = line.strip_prefix("opts:") {
+                    opts = Some(stripped.trim().split(',').map(|s| s.to_string()).collect());
+                } else if let Some(stripped) = line.strip_prefix("age:") {
+                    age = Some(Duration::from_secs(from_str!(u64, stripped.trim())));
+                } else if let Some(stripped) = line.strip_prefix("caps:") {
+                    caps = Some(stripped.trim().split(',').map(|s| s.to_string()).collect());
+                } else if let Some(stripped) = line.strip_prefix("sec:") {
+                    sec = Some(stripped.trim().split(',').map(|s| s.to_string()).collect());
+                } else if let Some(stripped) = line.strip_prefix("bytes:") {
+                    bytes = Some(NFSByteCounter::from_str(stripped.trim())?);
+                } else if let Some(stripped) = line.strip_prefix("events:") {
+                    events = Some(NFSEventCounter::from_str(stripped.trim())?);
                 }
                 if line == "per-op statistics" {
                     parsing_per_op = true;
@@ -353,8 +353,8 @@ impl MountNFSStatistics {
     /// Attempts to parse the caps= value from the [caps](struct.MountNFSStatistics.html#structfield.caps) field.
     pub fn server_caps(&self) -> ProcResult<Option<NFSServerCaps>> {
         for data in &self.caps {
-            if data.starts_with("caps=0x") {
-                let val = from_str!(u32, &data[7..], 16);
+            if let Some(stripped) = data.strip_prefix("caps=0x") {
+                let val = from_str!(u32, stripped, 16);
                 return Ok(NFSServerCaps::from_bits(val));
             }
         }

--- a/src/process/mount.rs
+++ b/src/process/mount.rs
@@ -370,67 +370,66 @@ impl MountNFSStatistics {
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NFSEventCounter {
-    pub inode_revalidate: libc::c_ulong,
-    pub deny_try_revalidate: libc::c_ulong,
-    pub data_invalidate: libc::c_ulong,
-    pub attr_invalidate: libc::c_ulong,
-    pub vfs_open: libc::c_ulong,
-    pub vfs_lookup: libc::c_ulong,
-    pub vfs_access: libc::c_ulong,
-    pub vfs_update_page: libc::c_ulong,
-    pub vfs_read_page: libc::c_ulong,
-    pub vfs_read_pages: libc::c_ulong,
-    pub vfs_write_page: libc::c_ulong,
-    pub vfs_write_pages: libc::c_ulong,
-    pub vfs_get_dents: libc::c_ulong,
-    pub vfs_set_attr: libc::c_ulong,
-    pub vfs_flush: libc::c_ulong,
-    pub vfs_fs_sync: libc::c_ulong,
-    pub vfs_lock: libc::c_ulong,
-    pub vfs_release: libc::c_ulong,
-    pub congestion_wait: libc::c_ulong,
-    pub set_attr_trunc: libc::c_ulong,
-    pub extend_write: libc::c_ulong,
-    pub silly_rename: libc::c_ulong,
-    pub short_read: libc::c_ulong,
-    pub short_write: libc::c_ulong,
-    pub delay: libc::c_ulong,
-    pub pnfs_read: libc::c_ulong,
-    pub pnfs_write: libc::c_ulong,
+    pub inode_revalidate: u64,
+    pub deny_try_revalidate: u64,
+    pub data_invalidate: u64,
+    pub attr_invalidate: u64,
+    pub vfs_open: u64,
+    pub vfs_lookup: u64,
+    pub vfs_access: u64,
+    pub vfs_update_page: u64,
+    pub vfs_read_page: u64,
+    pub vfs_read_pages: u64,
+    pub vfs_write_page: u64,
+    pub vfs_write_pages: u64,
+    pub vfs_get_dents: u64,
+    pub vfs_set_attr: u64,
+    pub vfs_flush: u64,
+    pub vfs_fs_sync: u64,
+    pub vfs_lock: u64,
+    pub vfs_release: u64,
+    pub congestion_wait: u64,
+    pub set_attr_trunc: u64,
+    pub extend_write: u64,
+    pub silly_rename: u64,
+    pub short_read: u64,
+    pub short_write: u64,
+    pub delay: u64,
+    pub pnfs_read: u64,
+    pub pnfs_write: u64,
 }
 
 impl NFSEventCounter {
     fn from_str(s: &str) -> ProcResult<NFSEventCounter> {
-        use libc::c_ulong;
         let mut s = s.split_whitespace();
         Ok(NFSEventCounter {
-            inode_revalidate: from_str!(c_ulong, expect!(s.next())),
-            deny_try_revalidate: from_str!(c_ulong, expect!(s.next())),
-            data_invalidate: from_str!(c_ulong, expect!(s.next())),
-            attr_invalidate: from_str!(c_ulong, expect!(s.next())),
-            vfs_open: from_str!(c_ulong, expect!(s.next())),
-            vfs_lookup: from_str!(c_ulong, expect!(s.next())),
-            vfs_access: from_str!(c_ulong, expect!(s.next())),
-            vfs_update_page: from_str!(c_ulong, expect!(s.next())),
-            vfs_read_page: from_str!(c_ulong, expect!(s.next())),
-            vfs_read_pages: from_str!(c_ulong, expect!(s.next())),
-            vfs_write_page: from_str!(c_ulong, expect!(s.next())),
-            vfs_write_pages: from_str!(c_ulong, expect!(s.next())),
-            vfs_get_dents: from_str!(c_ulong, expect!(s.next())),
-            vfs_set_attr: from_str!(c_ulong, expect!(s.next())),
-            vfs_flush: from_str!(c_ulong, expect!(s.next())),
-            vfs_fs_sync: from_str!(c_ulong, expect!(s.next())),
-            vfs_lock: from_str!(c_ulong, expect!(s.next())),
-            vfs_release: from_str!(c_ulong, expect!(s.next())),
-            congestion_wait: from_str!(c_ulong, expect!(s.next())),
-            set_attr_trunc: from_str!(c_ulong, expect!(s.next())),
-            extend_write: from_str!(c_ulong, expect!(s.next())),
-            silly_rename: from_str!(c_ulong, expect!(s.next())),
-            short_read: from_str!(c_ulong, expect!(s.next())),
-            short_write: from_str!(c_ulong, expect!(s.next())),
-            delay: from_str!(c_ulong, expect!(s.next())),
-            pnfs_read: from_str!(c_ulong, expect!(s.next())),
-            pnfs_write: from_str!(c_ulong, expect!(s.next())),
+            inode_revalidate: from_str!(u64, expect!(s.next())),
+            deny_try_revalidate: from_str!(u64, expect!(s.next())),
+            data_invalidate: from_str!(u64, expect!(s.next())),
+            attr_invalidate: from_str!(u64, expect!(s.next())),
+            vfs_open: from_str!(u64, expect!(s.next())),
+            vfs_lookup: from_str!(u64, expect!(s.next())),
+            vfs_access: from_str!(u64, expect!(s.next())),
+            vfs_update_page: from_str!(u64, expect!(s.next())),
+            vfs_read_page: from_str!(u64, expect!(s.next())),
+            vfs_read_pages: from_str!(u64, expect!(s.next())),
+            vfs_write_page: from_str!(u64, expect!(s.next())),
+            vfs_write_pages: from_str!(u64, expect!(s.next())),
+            vfs_get_dents: from_str!(u64, expect!(s.next())),
+            vfs_set_attr: from_str!(u64, expect!(s.next())),
+            vfs_flush: from_str!(u64, expect!(s.next())),
+            vfs_fs_sync: from_str!(u64, expect!(s.next())),
+            vfs_lock: from_str!(u64, expect!(s.next())),
+            vfs_release: from_str!(u64, expect!(s.next())),
+            congestion_wait: from_str!(u64, expect!(s.next())),
+            set_attr_trunc: from_str!(u64, expect!(s.next())),
+            extend_write: from_str!(u64, expect!(s.next())),
+            silly_rename: from_str!(u64, expect!(s.next())),
+            short_read: from_str!(u64, expect!(s.next())),
+            short_write: from_str!(u64, expect!(s.next())),
+            delay: from_str!(u64, expect!(s.next())),
+            pnfs_read: from_str!(u64, expect!(s.next())),
+            pnfs_write: from_str!(u64, expect!(s.next())),
         })
     }
 }
@@ -443,29 +442,28 @@ impl NFSEventCounter {
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NFSByteCounter {
-    pub normal_read: libc::c_ulonglong,
-    pub normal_write: libc::c_ulonglong,
-    pub direct_read: libc::c_ulonglong,
-    pub direct_write: libc::c_ulonglong,
-    pub server_read: libc::c_ulonglong,
-    pub server_write: libc::c_ulonglong,
-    pub pages_read: libc::c_ulonglong,
-    pub pages_write: libc::c_ulonglong,
+    pub normal_read: u64,
+    pub normal_write: u64,
+    pub direct_read: u64,
+    pub direct_write: u64,
+    pub server_read: u64,
+    pub server_write: u64,
+    pub pages_read: u64,
+    pub pages_write: u64,
 }
 
 impl NFSByteCounter {
     fn from_str(s: &str) -> ProcResult<NFSByteCounter> {
-        use libc::c_ulonglong;
         let mut s = s.split_whitespace();
         Ok(NFSByteCounter {
-            normal_read: from_str!(c_ulonglong, expect!(s.next())),
-            normal_write: from_str!(c_ulonglong, expect!(s.next())),
-            direct_read: from_str!(c_ulonglong, expect!(s.next())),
-            direct_write: from_str!(c_ulonglong, expect!(s.next())),
-            server_read: from_str!(c_ulonglong, expect!(s.next())),
-            server_write: from_str!(c_ulonglong, expect!(s.next())),
-            pages_read: from_str!(c_ulonglong, expect!(s.next())),
-            pages_write: from_str!(c_ulonglong, expect!(s.next())),
+            normal_read: from_str!(u64, expect!(s.next())),
+            normal_write: from_str!(u64, expect!(s.next())),
+            direct_read: from_str!(u64, expect!(s.next())),
+            direct_write: from_str!(u64, expect!(s.next())),
+            server_read: from_str!(u64, expect!(s.next())),
+            server_write: from_str!(u64, expect!(s.next())),
+            pages_read: from_str!(u64, expect!(s.next())),
+            pages_write: from_str!(u64, expect!(s.next())),
         })
     }
 }
@@ -503,15 +501,15 @@ impl NFSByteCounter {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct NFSOperationStat {
     /// Count of rpc operations.
-    pub operations: libc::c_ulong,
+    pub operations: u64,
     /// Count of rpc transmissions
-    pub transmissions: libc::c_ulong,
+    pub transmissions: u64,
     /// Count of rpc major timeouts
-    pub major_timeouts: libc::c_ulong,
+    pub major_timeouts: u64,
     /// Count of bytes send. Does not only include the RPC payload but the RPC headers as well.
-    pub bytes_sent: libc::c_ulonglong,
+    pub bytes_sent: u64,
     /// Count of bytes received as `bytes_sent`.
-    pub bytes_recv: libc::c_ulonglong,
+    pub bytes_recv: u64,
     /// How long all requests have spend in the queue before being send.
     pub cum_queue_time: Duration,
     /// How long it took to get a response back.
@@ -523,14 +521,13 @@ pub struct NFSOperationStat {
 
 impl NFSOperationStat {
     fn from_str(s: &str) -> ProcResult<NFSOperationStat> {
-        use libc::{c_ulong, c_ulonglong};
         let mut s = s.split_whitespace();
 
-        let operations = from_str!(c_ulong, expect!(s.next()));
-        let transmissions = from_str!(c_ulong, expect!(s.next()));
-        let major_timeouts = from_str!(c_ulong, expect!(s.next()));
-        let bytes_sent = from_str!(c_ulonglong, expect!(s.next()));
-        let bytes_recv = from_str!(c_ulonglong, expect!(s.next()));
+        let operations = from_str!(u64, expect!(s.next()));
+        let transmissions = from_str!(u64, expect!(s.next()));
+        let major_timeouts = from_str!(u64, expect!(s.next()));
+        let bytes_sent = from_str!(u64, expect!(s.next()));
+        let bytes_recv = from_str!(u64, expect!(s.next()));
         let cum_queue_time_ms = from_str!(u64, expect!(s.next()));
         let cum_resp_time_ms = from_str!(u64, expect!(s.next()));
         let cum_total_req_time_ms = from_str!(u64, expect!(s.next()));

--- a/src/process/mount.rs
+++ b/src/process/mount.rs
@@ -42,8 +42,7 @@ bitflags! {
 impl super::Process {
     /// Returns the [MountStat] data for this processes mount namespace.
     pub fn mountstats(&self) -> ProcResult<Vec<MountStat>> {
-        let path = self.root.join("mountstats");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "mountstats")?;
         MountStat::from_reader(file)
     }
 
@@ -53,8 +52,7 @@ impl super::Process {
     ///
     /// (Since Linux 2.6.26)
     pub fn mountinfo(&self) -> ProcResult<Vec<MountInfo>> {
-        let path = self.root.join("mountinfo");
-        let file = FileWrapper::open(&path)?;
+        let file = FileWrapper::open_at(&self.root, &self.fd, "mountinfo")?;
         let bufread = BufReader::new(file);
         let lines = bufread.lines();
         let mut vec = Vec::new();

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -30,9 +30,8 @@ macro_rules! since_kernel {
 ///
 /// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Stat {
-    _private: (),
-
     /// The process ID.
     pub pid: i32,
     /// The filename of the executable, in parentheses.
@@ -317,7 +316,6 @@ impl Stat {
         let exit_code = since_kernel!(3, 5, 0, expect!(from_iter(&mut rest)));
 
         Ok(Stat {
-            _private: (),
             pid,
             comm,
             state,

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -139,7 +139,7 @@ pub struct Stat {
     ///
     /// This is just the pages which count toward text,  data,  or stack space.
     /// This does not include pages which have not been demand-loaded in, or which are swapped out.
-    pub rss: i64,
+    pub rss: u64,
     /// Current soft limit in bytes on the rss of the process; see the description of RLIMIT_RSS in
     /// getrlimit(2).
     pub rsslim: u64,
@@ -414,7 +414,7 @@ impl Stat {
     /// Gets the Resident Set Size (in bytes)
     ///
     /// The `rss` field will return the same value in pages
-    pub fn rss_bytes(&self) -> ProcResult<i64> {
+    pub fn rss_bytes(&self) -> ProcResult<u64> {
         let pagesize = PAGESIZE
             .as_ref()
             .map_err(|e| ProcError::Other(format!("Failed to get pagesize: {:?}", e)))?;

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -14,8 +14,8 @@ use std::io::{BufRead, BufReader, Read};
 ///
 /// New fields to this struct may be added at any time (even without a major or minor semver bump).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Status {
-    _private: (),
     /// Command run by this process.
     pub name: String,
     /// Process umask, expressed in octal with a leading zero; see umask(2).  (Since Linux 4.7.)
@@ -192,7 +192,6 @@ impl Status {
         }
 
         let status = Status {
-            _private: (),
             name: expect!(map.remove("Name")),
             umask: map.remove("Umask").map(|x| Ok(from_str!(u32, &x, 8))).transpose()?,
             state: expect!(map.remove("State")),

--- a/src/process/status.rs
+++ b/src/process/status.rs
@@ -342,12 +342,13 @@ mod tests {
     #[test]
     fn test_proc_status() {
         let myself = Process::myself().unwrap();
+        let stat = myself.stat().unwrap();
         let status = myself.status().unwrap();
         println!("{:?}", status);
 
-        assert_eq!(status.name, myself.stat.comm);
-        assert_eq!(status.pid, myself.stat.pid);
-        assert_eq!(status.ppid, myself.stat.ppid);
+        assert_eq!(status.name, stat.comm);
+        assert_eq!(status.pid, stat.pid);
+        assert_eq!(status.ppid, stat.ppid);
     }
 
     #[test]

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -11,7 +11,7 @@ use rustix::io::OwnedFd;
 /// general are similar to Processes and should have mostly the same fields.
 #[derive(Debug)]
 pub struct Task {
-    pub fd: OwnedFd,
+    fd: OwnedFd,
     /// The ID of the process that this task belongs to
     pub pid: i32,
     /// The task ID

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -7,7 +7,7 @@ use crate::ProcResult;
 ///
 /// Created by [`Process::tasks`](crate::process::Process::tasks), tasks in
 /// general are similar to Processes and should have mostly the same fields.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Task {
     /// The ID of the process that this task belongs to
     pub pid: i32,
@@ -22,7 +22,7 @@ impl Task {
     pub fn new(pid: i32, tid: i32) -> Result<Task, ProcError> {
         let root = PathBuf::from(format!("/proc/{}/task/{}", pid, tid));
         if root.exists() {
-            Ok(Task { pid, tid, root })
+            Ok(Task { pid, tid: tid, root })
         } else {
             Err(ProcError::NotFound(Some(root)))
         }

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -162,7 +162,7 @@ mod tests {
             if stat.comm == "one" && status.name == "one" {
                 found_one = true;
                 assert!(io.rchar >= bytes_to_read);
-                assert!(stat.utime >= 1, "utime({}) too small", stat.utime);
+                assert!(stat.utime >= 50, "utime({}) too small", stat.utime);
             }
             if stat.comm == "two" && status.name == "two" {
                 found_two = true;

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use super::{FileWrapper, Io, ProcError, Schedstat, Stat, Status};
+use super::{FileWrapper, Io, Schedstat, Stat, Status};
 use crate::ProcResult;
+use rustix::fd::BorrowedFd;
+use rustix::io::OwnedFd;
 
 /// A task (aka Thread) inside of a [`Process`](crate::process::Process)
 ///
@@ -9,6 +11,7 @@ use crate::ProcResult;
 /// general are similar to Processes and should have mostly the same fields.
 #[derive(Debug)]
 pub struct Task {
+    pub fd: OwnedFd,
     /// The ID of the process that this task belongs to
     pub pid: i32,
     /// The task ID
@@ -18,54 +21,59 @@ pub struct Task {
 }
 
 impl Task {
-    /// Create a new `Task`
-    pub fn new(pid: i32, tid: i32) -> Result<Task, ProcError> {
-        let root = PathBuf::from(format!("/proc/{}/task/{}", pid, tid));
-        if root.exists() {
-            Ok(Task { pid, tid: tid, root })
-        } else {
-            Err(ProcError::NotFound(Some(root)))
-        }
-    }
-
     /// Create a new `Task` inside of the process
     ///
     /// This API is designed to be ergonomic from inside of [`TasksIter`](super::TasksIter)
-    pub(crate) fn from_rel_path(pid: i32, tid: &Path) -> Result<Task, ProcError> {
-        let root = PathBuf::from(format!("/proc/{}/task", pid)).join(tid);
-        Ok(Task {
-            pid,
-            tid: tid.file_name().unwrap().to_string_lossy().parse()?,
+    pub(crate) fn from_process_at<P: AsRef<Path>, Q: AsRef<Path>>(
+        base: P,
+        dirfd: BorrowedFd,
+        path: Q,
+        pid: i32,
+        tid: i32,
+    ) -> ProcResult<Task> {
+        use rustix::fs::{Mode, OFlags};
+
+        let p = path.as_ref();
+        let root = base.as_ref().join(p);
+        let fd = wrap_io_error!(
             root,
-        })
+            rustix::fs::openat(
+                dirfd,
+                p,
+                OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                Mode::empty()
+            )
+        )?;
+
+        Ok(Task { fd, pid, tid, root })
     }
 
     /// Thread info from `/proc/<pid>/task/<tid>/stat`
     ///
     /// Many of the returned fields will be the same as the parent process, but some fields like `utime` and `stime` will be per-task
     pub fn stat(&self) -> ProcResult<Stat> {
-        Stat::from_reader(FileWrapper::open(self.root.join("stat"))?)
+        Stat::from_reader(FileWrapper::open_at(&self.root, &self.fd, "stat")?)
     }
 
     /// Thread info from `/proc/<pid>/task/<tid>/status`
     ///
     /// Many of the returned fields will be the same as the parent process
     pub fn status(&self) -> ProcResult<Status> {
-        Status::from_reader(FileWrapper::open(self.root.join("status"))?)
+        Status::from_reader(FileWrapper::open_at(&self.root, &self.fd, "status")?)
     }
 
     /// Thread IO info from `/proc/<pid>/task/<tid>/io`
     ///
     /// This data will be unique per task.
     pub fn io(&self) -> ProcResult<Io> {
-        Io::from_reader(FileWrapper::open(self.root.join("io"))?)
+        Io::from_reader(FileWrapper::open_at(&self.root, &self.fd, "io")?)
     }
 
     /// Thread scheduler info from `/proc/<pid>/task/<tid>/schedstat`
     ///
     /// This data will be unique per task.
     pub fn schedstat(&self) -> ProcResult<Schedstat> {
-        Schedstat::from_reader(FileWrapper::open(self.root.join("schedstat"))?)
+        Schedstat::from_reader(FileWrapper::open_at(&self.root, &self.fd, "schedstat")?)
     }
 }
 
@@ -154,7 +162,7 @@ mod tests {
             if stat.comm == "one" && status.name == "one" {
                 found_one = true;
                 assert!(io.rchar >= bytes_to_read);
-                assert!(stat.utime >= 50, "utime({}) too small", stat.utime);
+                assert!(stat.utime >= 1, "utime({}) too small", stat.utime);
             }
             if stat.comm == "two" && status.name == "two" {
                 found_two = true;

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 fn check_unwrap<T>(prc: &Process, val: ProcResult<T>) -> Option<T> {
     match val {
         Ok(t) => Some(t),
-        Err(ProcError::PermissionDenied(_)) if unsafe { libc::geteuid() } != 0 => {
+        Err(ProcError::PermissionDenied(_)) if !rustix::process::geteuid().is_root() => {
             // we are not root, and so a permission denied error is OK
             None
         }
@@ -21,7 +21,7 @@ fn check_unwrap<T>(prc: &Process, val: ProcResult<T>) -> Option<T> {
 fn check_unwrap_task<T>(prc: &Process, val: ProcResult<T>) -> Option<T> {
     match val {
         Ok(t) => Some(t),
-        Err(ProcError::PermissionDenied(_)) if unsafe { libc::geteuid() } != 0 => {
+        Err(ProcError::PermissionDenied(_)) if !rustix::process::geteuid().is_root() => {
             // we are not root, and so a permission denied error is OK
             None
         }
@@ -218,7 +218,7 @@ fn test_error_handling() {
     // getting the proc struct should be OK
     let init = Process::new(1).unwrap();
 
-    let i_have_access = unsafe { libc::geteuid() } == init.owner;
+    let i_have_access = rustix::process::geteuid().as_raw() == init.owner;
 
     if !i_have_access {
         // but accessing data should result in an error (unless we are running as root!)

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -220,7 +220,7 @@ fn test_error_handling() {
     // getting the proc struct should be OK
     let init = Process::new(1).unwrap();
 
-    let i_have_access = rustix::process::geteuid().as_raw() == init.metadata().unwrap().st_uid;
+    let i_have_access = rustix::process::geteuid().as_raw() == init.uid().unwrap();
 
     if !i_have_access {
         // but accessing data should result in an error (unless we are running as root!)

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -44,79 +44,79 @@ fn test_main_thread_task() {
 #[allow(clippy::cognitive_complexity)]
 #[test]
 fn test_self_proc() {
-    let myself = Process::myself().unwrap();
+    let myself = Process::myself().unwrap().stat().unwrap();
     println!("{:#?}", myself);
-    println!("state: {:?}", myself.stat.state());
-    println!("tty: {:?}", myself.stat.tty_nr());
-    println!("flags: {:?}", myself.stat.flags());
+    println!("state: {:?}", myself.state());
+    println!("tty: {:?}", myself.tty_nr());
+    println!("flags: {:?}", myself.flags());
 
     #[cfg(feature = "chrono")]
-    println!("starttime: {:#?}", myself.stat.starttime());
+    println!("starttime: {:#?}", myself.starttime());
 
     let kernel = KernelVersion::current().unwrap();
 
     if kernel >= KernelVersion::new(2, 1, 22) {
-        assert!(myself.stat.exit_signal.is_some());
+        assert!(myself.exit_signal.is_some());
     } else {
-        assert!(myself.stat.exit_signal.is_none());
+        assert!(myself.exit_signal.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 2, 8) {
-        assert!(myself.stat.processor.is_some());
+        assert!(myself.processor.is_some());
     } else {
-        assert!(myself.stat.processor.is_none());
+        assert!(myself.processor.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 5, 19) {
-        assert!(myself.stat.rt_priority.is_some());
+        assert!(myself.rt_priority.is_some());
     } else {
-        assert!(myself.stat.rt_priority.is_none());
+        assert!(myself.rt_priority.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 5, 19) {
-        assert!(myself.stat.rt_priority.is_some());
-        assert!(myself.stat.policy.is_some());
+        assert!(myself.rt_priority.is_some());
+        assert!(myself.policy.is_some());
     } else {
-        assert!(myself.stat.rt_priority.is_none());
-        assert!(myself.stat.policy.is_none());
+        assert!(myself.rt_priority.is_none());
+        assert!(myself.policy.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 6, 18) {
-        assert!(myself.stat.delayacct_blkio_ticks.is_some());
+        assert!(myself.delayacct_blkio_ticks.is_some());
     } else {
-        assert!(myself.stat.delayacct_blkio_ticks.is_none());
+        assert!(myself.delayacct_blkio_ticks.is_none());
     }
 
     if kernel >= KernelVersion::new(2, 6, 24) {
-        assert!(myself.stat.guest_time.is_some());
-        assert!(myself.stat.cguest_time.is_some());
+        assert!(myself.guest_time.is_some());
+        assert!(myself.cguest_time.is_some());
     } else {
-        assert!(myself.stat.guest_time.is_none());
-        assert!(myself.stat.cguest_time.is_none());
+        assert!(myself.guest_time.is_none());
+        assert!(myself.cguest_time.is_none());
     }
 
     if kernel >= KernelVersion::new(3, 3, 0) {
-        assert!(myself.stat.start_data.is_some());
-        assert!(myself.stat.end_data.is_some());
-        assert!(myself.stat.start_brk.is_some());
+        assert!(myself.start_data.is_some());
+        assert!(myself.end_data.is_some());
+        assert!(myself.start_brk.is_some());
     } else {
-        assert!(myself.stat.start_data.is_none());
-        assert!(myself.stat.end_data.is_none());
-        assert!(myself.stat.start_brk.is_none());
+        assert!(myself.start_data.is_none());
+        assert!(myself.end_data.is_none());
+        assert!(myself.start_brk.is_none());
     }
 
     if kernel >= KernelVersion::new(3, 5, 0) {
-        assert!(myself.stat.arg_start.is_some());
-        assert!(myself.stat.arg_end.is_some());
-        assert!(myself.stat.env_start.is_some());
-        assert!(myself.stat.env_end.is_some());
-        assert!(myself.stat.exit_code.is_some());
+        assert!(myself.arg_start.is_some());
+        assert!(myself.arg_end.is_some());
+        assert!(myself.env_start.is_some());
+        assert!(myself.env_end.is_some());
+        assert!(myself.exit_code.is_some());
     } else {
-        assert!(myself.stat.arg_start.is_none());
-        assert!(myself.stat.arg_end.is_none());
-        assert!(myself.stat.env_start.is_none());
-        assert!(myself.stat.env_end.is_none());
-        assert!(myself.stat.exit_code.is_none());
+        assert!(myself.arg_start.is_none());
+        assert!(myself.arg_end.is_none());
+        assert!(myself.env_start.is_none());
+        assert!(myself.env_end.is_none());
+        assert!(myself.exit_code.is_none());
     }
 }
 
@@ -134,20 +134,22 @@ fn test_all() {
             })
         })
         .unwrap_or(false);
-    for prc in all_processes().unwrap() {
+    for p in all_processes().unwrap() {
         // note: this test doesn't unwrap, since some of this data requires root to access
         // so permission denied errors are common.  The check_unwrap helper function handles
         // this.
 
-        println!("{} {}", prc.pid(), prc.stat.comm);
-        prc.stat.flags().unwrap();
-        prc.stat.state().unwrap();
+        let prc = p.unwrap();
+        let stat = prc.stat().unwrap();
+        println!("{} {}", prc.pid(), stat.comm);
+        stat.flags().unwrap();
+        stat.state().unwrap();
         #[cfg(feature = "chrono")]
-        prc.stat.starttime().unwrap();
+        stat.starttime().unwrap();
 
         // if this process is defunct/zombie, don't try to read any of the below data
         // (some might be successful, but not all)
-        if prc.stat.state().unwrap() == ProcState::Zombie {
+        if stat.state().unwrap() == ProcState::Zombie {
             continue;
         }
 
@@ -218,7 +220,7 @@ fn test_error_handling() {
     // getting the proc struct should be OK
     let init = Process::new(1).unwrap();
 
-    let i_have_access = rustix::process::geteuid().as_raw() == init.owner;
+    let i_have_access = rustix::process::geteuid().as_raw() == init.metadata().unwrap().st_uid;
 
     if !i_have_access {
         // but accessing data should result in an error (unless we are running as root!)
@@ -269,7 +271,8 @@ fn test_mmap_path() {
 #[test]
 fn test_proc_fds() {
     let myself = Process::myself().unwrap();
-    for fd in myself.fd().unwrap() {
+    for f in myself.fd().unwrap() {
+        let fd = f.unwrap();
         println!("{:?} {:?}", fd, fd.mode());
     }
 }
@@ -277,7 +280,7 @@ fn test_proc_fds() {
 #[test]
 fn test_proc_fd() {
     let myself = Process::myself().unwrap();
-    let raw_fd = myself.fd().unwrap().get(0).unwrap().fd as i32;
+    let raw_fd = myself.fd().unwrap().next().unwrap().unwrap().fd as i32;
     let fd = FDInfo::from_raw_fd(myself.pid, raw_fd).unwrap();
     println!("{:?} {:?}", fd, fd.mode());
 }
@@ -338,7 +341,7 @@ fn test_procinfo() {
 
     let procinfo_stat = procinfo::pid::stat_self().unwrap();
     let me = Process::myself().unwrap();
-    let me_stat = me.stat;
+    let me_stat = me.stat().unwrap();
 
     diff_mem(procinfo_stat.vsize as f32, me_stat.vsize as f32);
 

--- a/src/sys/fs/binfmt_misc.rs
+++ b/src/sys/fs/binfmt_misc.rs
@@ -68,19 +68,19 @@ impl BinFmtEntry {
         for line in data.lines() {
             if line == "enabled" {
                 enabled = true;
-            } else if line.starts_with("interpreter ") {
-                interpreter = line[12..].to_string();
-            } else if line.starts_with("flags:") {
-                flags = BinFmtFlags::from_str(&line[6..]);
-            } else if line.starts_with("extension .") {
-                ext = Some(line[11..].to_string());
-            } else if line.starts_with("offset ") {
-                offset = from_str!(u8, &line[7..]);
-            } else if line.starts_with("magic ") {
-                let hex = &line[6..];
+            } else if let Some(stripped) = line.strip_prefix("interpreter ") {
+                interpreter = stripped.to_string();
+            } else if let Some(stripped) = line.strip_prefix("flags:") {
+                flags = BinFmtFlags::from_str(stripped);
+            } else if let Some(stripped) = line.strip_prefix("extension .") {
+                ext = Some(stripped.to_string());
+            } else if let Some(stripped) = line.strip_prefix("offset ") {
+                offset = from_str!(u8, stripped);
+            } else if let Some(stripped) = line.strip_prefix("magic ") {
+                let hex = stripped;
                 magic = hex_to_vec(dbg!(hex))?;
-            } else if line.starts_with("mask ") {
-                let hex = &line[5..];
+            } else if let Some(stripped) = line.strip_prefix("mask ") {
+                let hex = stripped;
                 mask = hex_to_vec(hex)?;
             }
         }

--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -222,8 +222,8 @@ impl FromStr for BuildInfo {
         let mut splited = s.split(' ');
         let version_str = splited.next();
         if let Some(version_str) = version_str {
-            if version_str.starts_with('#') {
-                version.push_str(&version_str[1..]);
+            if let Some(stripped) = version_str.strip_prefix('#') {
+                version.push_str(stripped);
             } else {
                 return Err("Failed to parse kernel build version");
             }

--- a/src/sys/kernel/mod.rs
+++ b/src/sys/kernel/mod.rs
@@ -441,7 +441,7 @@ pub fn threads_max() -> ProcResult<u32> {
 /// This function will return an error if that is not the case.
 pub fn set_threads_max(new_limit: u32) -> ProcResult<()> {
     if let Ok(kernel) = *KERNEL {
-        if kernel.major >= 4 && kernel.minor >= 1 && !(THREADS_MIN <= new_limit && new_limit <= THREADS_MAX) {
+        if kernel.major >= 4 && kernel.minor >= 1 && !(THREADS_MIN..=THREADS_MAX).contains(&new_limit) {
             return Err(ProcError::Other(format!(
                 "{} is outside the THREADS_MIN..=THREADS_MAX range",
                 new_limit

--- a/src/sysvipc_shm.rs
+++ b/src/sysvipc_shm.rs
@@ -1,7 +1,5 @@
 use std::io;
 
-use libc::pid_t;
-
 use super::{FileWrapper, ProcResult};
 use std::str::FromStr;
 
@@ -19,9 +17,9 @@ pub struct Shm {
     /// Size in bytes
     pub size: u32,
     /// Creator PID
-    pub cpid: pid_t,
+    pub cpid: i32,
     /// Last operator PID
-    pub lpid: pid_t,
+    pub lpid: i32,
     /// Number of attached processes
     pub nattch: u32,
     /// User ID
@@ -69,8 +67,8 @@ impl Shm {
             let shmid = expect!(u64::from_str(expect!(s.next())));
             let perms = expect!(u16::from_str(expect!(s.next())));
             let size = expect!(u32::from_str(expect!(s.next())));
-            let cpid = expect!(pid_t::from_str(expect!(s.next())));
-            let lpid = expect!(pid_t::from_str(expect!(s.next())));
+            let cpid = expect!(i32::from_str(expect!(s.next())));
+            let lpid = expect!(i32::from_str(expect!(s.next())));
             let nattch = expect!(u32::from_str(expect!(s.next())));
             let uid = expect!(u16::from_str(expect!(s.next())));
             let gid = expect!(u16::from_str(expect!(s.next())));

--- a/src/uptime.rs
+++ b/src/uptime.rs
@@ -6,9 +6,8 @@ use std::time::Duration;
 
 /// The uptime of the system, based on the `/proc/uptime` file.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Uptime {
-    _private: (),
-
     /// The uptime of the system (including time spent in suspend).
     pub uptime: f64,
 
@@ -33,11 +32,7 @@ impl Uptime {
         let uptime = expect!(f64::from_str(expect!(s.next())));
         let idle = expect!(f64::from_str(expect!(s.next())));
 
-        Ok(Uptime {
-            _private: (),
-            uptime,
-            idle,
-        })
+        Ok(Uptime { uptime, idle })
     }
 
     /// The uptime of the system (including time spent in suspend).


### PR DESCRIPTION
This updates and polishes the patch from #127, which seems to be abandoned, as the author is listed as @ghost. It uses `openat` and `readlinkat` to protect against PID reuse.

This also makes two additional changes: it adds a dependency on [rustix](https://crates.io/crates/rustix), which provides safe APIs for `openat`, `readlinkat`, and so on, and it bumps the MSRV to 1.48. I know you just recently bumped the MSRV to 1.42, but 1.48 is worth considering, as it's the version of Rust currently in Debian stable, it's newer than the version in the oldest still-supported Fedora release, and it eliminates the need for special instructions for the hex and bitflags dependencies. That said, people have different needs, and of course it's your call as to whether these changes are appropriate for procfs.

Fixes #125.