### PR TITLE
Update github-actions configuration to run all the github actions up to completion

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         toolchain: ["1.42.0", "stable", "beta", "nightly"]
     runs-on: ubuntu-latest
@@ -41,6 +42,7 @@ jobs:
 
   check:
     strategy:
+      fail-fast: false
       matrix:
         toolchain: ["1.42.0", "stable", "beta", "nightly"]
     runs-on: ubuntu-latest


### PR DESCRIPTION
By disabling fail-fast in the actions matrix we ensure that all the jobs defined by the matrix are executed up to their completion.

This is useful because while running checks or tests on multiple toolchain versions it is useful to have the report of all the versions and not and not stop the tests as soon as 1 toolchain version failed.

NOTE: This does not alter the fact that the overall actions run will be marked as failed.


The core reason of this change is that #168 tests are failing on version 1.34.0 but it is unclear if they were to fail on the other specified versions (1.42.0, stable, beta, nightly)