### PR TITLE
Add suport for /proc/[pid]/task/[tid]/children

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 default = ["chrono", "flate2"]
 
 [dependencies]
-rustix = { version = "0.35.6", features = ["fs", "process", "param"] }
+rustix = { version = "0.35.6", features = ["fs", "process", "param", "thread"] }
 bitflags = "1.2"
 lazy_static = "1.0.2"
 chrono = {version = "0.4.1", optional = true }

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -77,6 +77,9 @@ impl Task {
         Schedstat::from_reader(FileWrapper::open_at(&self.root, &self.fd, "schedstat")?)
     }
 
+    /// Thread children from `/proc/<pid>/task/<tid>/children`
+    ///
+    /// This data will be unique per task.
     pub fn children(&self) -> ProcResult<Vec<u32>> {
         let mut buf = String::new();
         let mut file = FileWrapper::open_at(&self.root, &self.fd, "children")?;

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -79,6 +79,11 @@ impl Task {
 
     /// Thread children from `/proc/<pid>/task/<tid>/children`
     ///
+    /// WARNING:
+    /// This interface is not reliable unless all the child processes are stoppped or frozen.
+    /// If a child task exits while the file is being read, non-exiting children may be omitted.
+    /// See the procfs(5) man page for more information.
+    ///
     /// This data will be unique per task.
     pub fn children(&self) -> ProcResult<Vec<u32>> {
         let mut buf = String::new();

--- a/support.md
+++ b/support.md
@@ -53,7 +53,7 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
     * [x] `/proc/[pid]/task/[tid]/stat`
     * [x] `/proc/[pid]/task/[tid]/status`
     * [x] `/proc/[pid]/task/[tid]/io`
-    * [ ] `/proc/[pid]/task/[tid]/children`
+    * [x] `/proc/[pid]/task/[tid]/children`
   * [ ] `/proc/[pid]/timers`
   * [ ] `/proc/[pid]/timerslack_ns`
   * [ ] `/proc/[pid]/uid_map`


### PR DESCRIPTION
While using this library I came across the need to find the children of a process. I saw that it was not supported, but it seemed fairly easy to implement so I took a shot at it.

I'm new to Rust so I welcome any suggestions.