### PR TITLE
Add 'from_reader' for LoadAverage struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,10 +568,16 @@ pub struct LoadAverage {
 impl LoadAverage {
     /// Reads load average info from `/proc/loadavg`
     pub fn new() -> ProcResult<LoadAverage> {
-        let mut f = FileWrapper::open("/proc/loadavg")?;
-        let mut s = String::new();
-        f.read_to_string(&mut s)?;
-        let mut s = s.split_whitespace();
+        LoadAverage::from_reader(FileWrapper::open("/proc/loadavg")?)
+    }
+
+    /// Get LoadAverage from a custom Read instead of the default `/proc/loadavg`.
+    pub fn from_reader<R: io::Read>(r: R) -> ProcResult<LoadAverage> {
+        let mut reader = BufReader::new(r);
+        let mut line = String::new();
+
+        reader.read_to_string(&mut line)?;
+        let mut s = line.split_whitespace();
 
         let one = expect!(f32::from_str(expect!(s.next())));
         let five = expect!(f32::from_str(expect!(s.next())));


### PR DESCRIPTION
Hello,

Thank you very much for this library ! It helps **a lot** !

Is it possible to add the possibility to read the load average from another directory than `/proc`  please ?

This PR is inspired from the `Meminfo` struct, adding a method `from_reader` in the `LoadAverage` struct.

Tests are ok
```
test result: ok. 105 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.02s
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.84s
```

Thank you !