### PR TITLE
Process: Namespace: Use openat instead of building a path

### DIFF
--- a/src/cgroups.rs
+++ b/src/cgroups.rs
@@ -88,10 +88,9 @@ impl Process {
     ///
     /// The displayed information differs for cgroupsversion 1 and version 2 hierarchies.
     pub fn cgroups(&self) -> ProcResult<Vec<ProcessCgroup>> {
-        use std::fs::File;
         use std::io::{BufRead, BufReader};
 
-        let file = File::open(self.root.join("cgroup"))?;
+        let file = self.open_relative("cgroup")?;
         let reader = BufReader::new(file);
 
         let mut vec = Vec::new();

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1405,6 +1405,12 @@ impl Process {
         let file = FileWrapper::open_at(&self.root, &self.fd, "mem")?;
         Ok(file.inner())
     }
+
+    /// Returns a file which is part of the process proc structure
+    pub fn open_relative(&self, path: &str) -> ProcResult<File> {
+        let file = FileWrapper::open_at(&self.root, &self.fd, path)?;
+        Ok(file.inner())
+    }
 }
 
 /// The result of [`Process::fd`], iterates over all fds in a process


### PR DESCRIPTION
This should resolve a case of a PID reuse

Signed-off-by: Jon Doron <jond@wiz.io>