### PR TITLE
Bump chorono to 0.4.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["chrono", "flate2"]
 rustix = { version = "0.35.6", features = ["fs", "process", "param", "thread"] }
 bitflags = "1.2"
 lazy_static = "1.0.2"
-chrono = {version = "0.4.1", optional = true }
+chrono = {version = "0.4.20", optional = true }
 byteorder = {version="1.2.3", features=["i128"]}
 hex = "0.4"
 flate2 = { version = "1.0.3", optional = true }


### PR DESCRIPTION
Chrono now - 0.4.20 - has localtime_r RIR that has addressed the past security issue around it :partying_face: 

We've updated here:
https://rustsec.org/advisories/RUSTSEC-2020-0159.html