### PR TITLE
Adjust serde derives on InternalError struct

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Pin plotters
       if: matrix.toolchain == '1.48.0'
       run: cargo update -p plotters --precise 0.3.1
+    - name: Pin serde
+      if: matrix.toolchain == '1.48.0'
+      run: cargo update -p serde --precise 1.0.142
     - name: Run tests
       run: cargo +${{ matrix.toolchain }} test --all-features --verbose -- --skip _runsinglethread
     - name: Run tests (single-threaded tests)
@@ -57,6 +60,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: i686-unknown-linux-gnu
 
+      - name: Pin serde
+        if: matrix.toolchain == '1.48.0'
+        run: cargo update -p serde --precise 1.0.142
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android --all-features
       - name: cargo check (i686)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following cargo features are available:
 * `chrono` -- Default.  Optional.  This feature enables a few methods that return values as `DateTime` objects.
 * `flate2` -- Default.  Optional.  This feature enables parsing gzip compressed `/proc/config.gz` file via the `procfs::kernel_config` method.
 * `backtrace` -- Optional.  This feature lets you get a stack trace whenever an `InternalError` is raised.
+* `serde1` -- Optional.  This feature allows most structs to be serialized and deserialized using serde 1.0.
 
 ## Minimum Rust Version
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ The following cargo features are available:
 * `chrono` -- Default.  Optional.  This feature enables a few methods that return values as `DateTime` objects.
 * `flate2` -- Default.  Optional.  This feature enables parsing gzip compressed `/proc/config.gz` file via the `procfs::kernel_config` method.
 * `backtrace` -- Optional.  This feature lets you get a stack trace whenever an `InternalError` is raised.
-* `serde1` -- Optional.  This feature allows most structs to be serialized and deserialized using serde 1.0.
+* `serde1` -- Optional.  This feature allows most structs to be serialized and deserialized using serde 1.0.  Note, this
+feature requires a version of rust newer than 1.48.0 (which is the MSRV for procfs).  The exact version required is not
+specified here, since serde does not not have an MSRV policy.
 
 ## Minimum Rust Version
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,12 +462,13 @@ pub enum ProcError {
 ///
 /// If you compile with the optional `backtrace` feature (disabled by default),
 /// you can gain access to a stack trace of where the error happened.
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde1", derive(Serialize))]
 pub struct InternalError {
     pub msg: String,
     pub file: &'static str,
     pub line: u32,
     #[cfg(feature = "backtrace")]
+    #[cfg_attr(feature = "serde1", serde(skip))]
     pub backtrace: backtrace::Backtrace,
 }
 


### PR DESCRIPTION
The optional `backtrace` feature is slightly problematic when deriving
Serialize and Deserialize.  By default, the `backtrace` crate doesn't support
serde, but it has an optional feature to do so.

Ideally, this problem would be solved by adjusting the dependency in
Cargo.toml:

```toml
[features]
serde1 = ["serde", "backtrace?/serde"]
```

But this syntax is only available in rust 1.60, while the MSRV for
procfs is 1.48.

So the until we bump our MSRV, the `backtrace` field will be skiped for
serialization.  Since this type has a `Default` impl, we could in theory
deserialize it, but that doesn't seem to make much sense, so the
`InternalError` struct no longer derives Deserialize.