### PR TITLE
[v0.13 backport] Don't consider Zombies to be alive

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -833,8 +833,14 @@ impl Process {
     }
 
     /// Is this process still alive?
+    /// 
+    /// Processes in the Zombie or Dead state are not considered alive.
     pub fn is_alive(&self) -> bool {
-        rustix::fs::statat(&self.fd, "stat", AtFlags::empty()).is_ok()
+        if let Ok(stat) = self.stat() {
+            stat.state != 'Z' && stat.state != 'X'
+        } else {
+            false
+        }
     }
 
     /// What user owns this process?


### PR DESCRIPTION
This backports the fix in #198 (20b118207249b8678116b91a7c902149c16084cc) to the v0.13 branch