### PR TITLE
[v0.13 backport] Pin serde in gitlab CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       run: cargo update -p plotters --precise 0.3.1
     - name: Pin serde
       if: matrix.toolchain == '1.48.0'
-      run: cargo update -p serde --precise 1.0.142
+      run: cargo update -p serde --precise 1.0.142 && cargo update -p serde_derive --precise 1.0.142
     - name: Run tests
       run: cargo +${{ matrix.toolchain }} test --verbose -- --skip _runsinglethread
     - name: Run tests (single-threaded tests)
@@ -62,7 +62,7 @@ jobs:
 
       - name: Pin serde
         if: matrix.toolchain == '1.48.0'
-        run: cargo update -p serde --precise 1.0.142
+        run: cargo update -p serde --precise 1.0.142 && cargo update -p serde_derive --precise 1.0.142
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
       - name: cargo check (i686)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Pin plotters
       if: matrix.toolchain == '1.48.0'
       run: cargo update -p plotters --precise 0.3.1
+    - name: Pin serde
+      if: matrix.toolchain == '1.48.0'
+      run: cargo update -p serde --precise 1.0.142
     - name: Run tests
       run: cargo +${{ matrix.toolchain }} test --verbose -- --skip _runsinglethread
     - name: Run tests (single-threaded tests)
@@ -57,6 +60,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: i686-unknown-linux-gnu
 
+      - name: Pin serde
+        if: matrix.toolchain == '1.48.0'
+        run: cargo update -p serde --precise 1.0.142
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android
       - name: cargo check (i686)


### PR DESCRIPTION
Fixes a (hopefully) temporary issue with serde on 1.48

(cherry picked from commit 32794c80e6fed18247cc27b1f431d03bb59b22ba)