### PR TITLE
Fix process iterator when used with a custom root 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1181,6 +1181,19 @@ mod tests {
     }
 
     #[test]
+    fn test_loadavg_from_reader() -> ProcResult<()> {
+        let load_average = LoadAverage::from_reader("2.63 1.00 1.42 3/4280 2496732".as_bytes())?;
+
+        assert_eq!(load_average.one, 2.63);
+        assert_eq!(load_average.five, 1.00);
+        assert_eq!(load_average.fifteen, 1.42);
+        assert_eq!(load_average.max, 4280);
+        assert_eq!(load_average.cur, 3);
+        assert_eq!(load_average.latest_pid, 2496732);
+        Ok(())
+    }
+
+    #[test]
     fn test_from_str() -> ProcResult<()> {
         assert_eq!(from_str!(u8, "12"), 12);
         assert_eq!(from_str!(u8, "A", 16), 10);


### PR DESCRIPTION
Hello,

My context is a lxc container with a limited version of `/proc` containing only processes that are running in the container.
The full proc mounted in another directory, `/proc-full`.

When I call `all_processes_with_root` with the root `/proc-full`, the iterator creates `Process` with the "default" constructor instead of the one with `with_root`: https://github.com/eminence/procfs/blob/master/src/process/mod.rs#L1541
The creation of the Process fails silently as there is no check for that and `all_processes_with_root` returns successfully, but without processes.
If I change that call with `Process::new_with_root`, it works.

As Rust is quite new to me I'm not sure that it is a good solution, can you have a look at it please ?

Thank you very much !

PS: I left some few commits from my last PR:
- In the tests I change the `failure` crate to `anyhow`. `failure` has been marked as deprecated : https://github.com/rust-lang-deprecated/failure
- add a new test for the ` loadavg_from_reader`
- Fix a `cargo clippy` warning

The test `sys::kernel::random::tests::test_poolsize` fails but it seems that is was failing before these modifications too.