### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Pin plotters
       if: matrix.toolchain == '1.48.0'
       run: cargo update -p plotters --precise 0.3.1
+    - name: Pin once_cell
+      if: matrix.toolchain == '1.48.0'
+      run: cargo update -p once_cell --precise 1.14.0
     - name: Run tests
       run: cargo +${{ matrix.toolchain }} test --all-features --verbose -- --skip _runsinglethread
     - name: Run tests (single-threaded tests)
@@ -57,6 +60,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: i686-unknown-linux-gnu
 
+      - name: Pin once_cell
+        if: matrix.toolchain == '1.48.0'
+        run: cargo update -p once_cell --precise 1.14.0
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android --all-features
       - name: cargo check (i686)

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -215,7 +215,7 @@ fn test_proc_alive() {
     let child_pid = child.id() as i32;
 
     // sleep very briefly to allow the child to start and then exit
-    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::thread::sleep(std::time::Duration::from_millis(30));
 
     let child_proc = Process::new(child_pid).unwrap();
     assert!(!child_proc.is_alive(), "Child state is: {:?}", child_proc.stat());

--- a/src/sys/kernel/random.rs
+++ b/src/sys/kernel/random.rs
@@ -73,7 +73,6 @@ mod tests {
         // The kernel support section in the root lib.rs file says that we only aim to support >= 2.6 kernels,
         // so only test that case
         let poolsize = poolsize().unwrap();
-        assert!(poolsize == 4096)
     }
 
     #[test]


### PR DESCRIPTION
once_cell upgraded to edition 2021, so Rust 1.48 can't compile it anymore
See https://github.com/matklad/once_cell/commit/b68bee9c56820dad7ad50b8e2a3b7be3fc690a53

Removed assert on poolsize, because recent kernel versions changed this
See https://unix.stackexchange.com/questions/704737/kernel-5-10-119-caused-the-values-of-proc-sys-kernel-random-entropy-avail-and-p

iana-time-zone v0.1.50 not yet release to crates.io to fix check (1.48.0), see https://github.com/strawlab/iana-time-zone/commit/0c296b55f5197840ad341576bab877b807d1bd42