### PR TITLE
Fix memfd fd target

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -670,7 +670,6 @@ impl FromStr for FDTarget {
                     Ok(FDTarget::Pipe(inode))
                 }
                 "anon_inode" => Ok(FDTarget::AnonInode(expect!(s.next(), "anon inode").to_string())),
-                "/memfd" => Ok(FDTarget::MemFD(expect!(s.next(), "memfd name").to_string())),
                 "" => Err(ProcError::Incomplete(None)),
                 x => {
                     let inode = expect!(s.next(), "other inode");
@@ -678,6 +677,8 @@ impl FromStr for FDTarget {
                     Ok(FDTarget::Other(x.to_string(), inode))
                 }
             }
+        } else if let Some(s) = s.strip_prefix("/memfd:") {
+            Ok(FDTarget::MemFD(s.to_string()))
         } else {
             Ok(FDTarget::Path(PathBuf::from(s)))
         }

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -479,3 +479,9 @@ fn test_fdtarget() {
     let _ = FDTarget::from_str("n:ǟF");
     let _ = FDTarget::from_str("pipe:");
 }
+
+#[test]
+fn test_fdtarget_memfd() {
+    let memfd = FDTarget::from_str("/memfd:test").unwrap();
+    assert!(matches!(memfd, FDTarget::MemFD(s) if s == "test"));
+}


### PR DESCRIPTION
Memfd case is unreachable since the whole match block is for `!s.starts_with('/')`.