### PR TITLE
Disabling default features on the `chrono` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde1 = ["serde"]
 rustix = { version = "0.35.6", features = ["fs", "process", "param", "thread"] }
 bitflags = "1.2"
 lazy_static = "1.0.2"
-chrono = {version = "0.4.20", optional = true }
+chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }
 byteorder = {version="1.2.3", features=["i128"]}
 hex = "0.4"
 flate2 = { version = "1.0.3", optional = true }


### PR DESCRIPTION
# Situation
The `chrono` crate depends on an outdated version of the `time` crate, which has a known vulnerability. `chrono` apparently does not use the vulnerable element, but it has breaking backwards compatibility issues and will not be removed until they upgrade the major version. There is a workaround suggested in https://github.com/chronotope/chrono/issues/602#issuecomment-1225331424. I've compiled it myself and confirm the vulnerable crate no longer is a dependency in `Cargo.lock`.

# Target
Remove the vulnerability to prevent vulnerability-tool noise.

# Proposal
In accordance with the workaround, disable the default features of `chrono` and instead replace it with the "clock" feature, which does not compile the vulnerable crate. 