### PR TITLE
Update to rustix 0.36.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["chrono", "flate2"]
 serde1 = ["serde"]
 
 [dependencies]
-rustix = { version = "0.35.6", features = ["fs", "process", "param", "thread"] }
+rustix = { version = "0.36.0", features = ["fs", "process", "param", "thread"] }
 bitflags = "1.2"
 lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 use bitflags::bitflags;
 use lazy_static::lazy_static;
 
-use rustix::fd::{AsFd, FromFd};
+use rustix::fd::AsFd;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Read, Seek, Write};
@@ -388,7 +388,7 @@ impl FileWrapper {
             rustix::fs::openat(dirfd, path.as_ref(), OFlags::RDONLY | OFlags::CLOEXEC, Mode::empty())
         )?;
         Ok(FileWrapper {
-            inner: File::from_fd(fd.into()),
+            inner: File::from(fd),
             path: p,
         })
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -60,9 +60,8 @@ use super::*;
 use crate::from_iter;
 use crate::net::{read_tcp_table, read_udp_table, TcpNetEntry, UdpNetEntry};
 
-use rustix::fd::{AsFd, BorrowedFd, RawFd};
+use rustix::fd::{AsFd, BorrowedFd, RawFd, OwnedFd};
 use rustix::fs::{AtFlags, Mode, OFlags, RawMode};
-use rustix::io::OwnedFd;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
@@ -1436,7 +1435,7 @@ impl Process {
 #[derive(Debug)]
 pub struct FDsIter {
     inner: rustix::fs::Dir,
-    inner_fd: rustix::io::OwnedFd,
+    inner_fd: rustix::fd::OwnedFd,
     root: PathBuf,
 }
 
@@ -1466,7 +1465,7 @@ impl std::iter::Iterator for FDsIter {
 pub struct TasksIter {
     pid: i32,
     inner: rustix::fs::Dir,
-    inner_fd: rustix::io::OwnedFd,
+    inner_fd: rustix::fd::OwnedFd,
     root: PathBuf,
 }
 

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -3,8 +3,7 @@ use std::path::{Path, PathBuf};
 
 use super::{FileWrapper, Io, Schedstat, Stat, Status};
 use crate::{ProcError, ProcResult};
-use rustix::fd::BorrowedFd;
-use rustix::io::OwnedFd;
+use rustix::fd::{OwnedFd, BorrowedFd};
 
 /// A task (aka Thread) inside of a [`Process`](crate::process::Process)
 ///


### PR DESCRIPTION
The main change here is the change to io-lifetimes 1.0, which uses the `OwnedFd` etc. from std, on Rust versions where it's available.

This version also drops the `FromFd` trait, because std uses `From<OwnedFd>` instead.