### PR TITLE
Add /proc/iomem

### DIFF
--- a/examples/iomem.rs
+++ b/examples/iomem.rs
@@ -10,13 +10,13 @@ fn main() {
 
     let iomem = procfs::iomem().expect("Can't read /proc/iomem");
 
-    for map in iomem.iter() {
+    for (indent, map) in iomem.iter() {
         if map.name == "System RAM" {
             println!("Found RAM here: 0x{:x}-0x{:x}", map.address.0, map.address.1);
         }
     }
 
     if !rustix::process::geteuid().is_root() {
-        println!("\n\nWARNING: Access to /proc/<PID>/pagemap requires root, re-run with sudo");
+        println!("\n\nWARNING: Access to /proc/iomem requires root, re-run with sudo");
     }
 }

--- a/examples/iomem.rs
+++ b/examples/iomem.rs
@@ -1,0 +1,22 @@
+//
+// Print physical location of system RAM
+// This requires CAP_SYS_ADMIN privilege, or root, otherwise physical memory addresses will be zero
+//
+
+fn main() {
+    if !rustix::process::geteuid().is_root() {
+        println!("WARNING: Access to /proc/iomem requires root, re-run with sudo");
+    }
+
+    let iomem = procfs::IoMem::new().expect("Can't read /proc/iomem");
+
+    for map in iomem.iter() {
+        if map.name == "System RAM" {
+            println!("Found RAM here: 0x{:x}-0x{:x}", map.address.0, map.address.1);
+        }
+    }
+
+    if !rustix::process::geteuid().is_root() {
+        println!("\n\nWARNING: Access to /proc/<PID>/pagemap requires root, re-run with sudo");
+    }
+}

--- a/examples/iomem.rs
+++ b/examples/iomem.rs
@@ -8,7 +8,7 @@ fn main() {
         println!("WARNING: Access to /proc/iomem requires root, re-run with sudo");
     }
 
-    let iomem = procfs::IoMem::new().expect("Can't read /proc/iomem");
+    let iomem = procfs::iomem().expect("Can't read /proc/iomem");
 
     for map in iomem.iter() {
         if map.name == "System RAM" {

--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -25,7 +25,7 @@ pub fn iomem() -> ProcResult<Vec<(usize, PhysicalMemoryMap)>> {
     Ok(vec)
 }
 
-/// To construct this structure, see [crate::IoMem::new].
+/// To construct this structure, see [crate::iomem()].
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PhysicalMemoryMap {

--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
+use std::io;
+
+use super::{FileWrapper, ProcResult};
+use crate::split_into_num;
+
+pub struct IoMem;
+
+impl IoMem {
+    /// Reads and parses the `/proc/iomem`, returning an error if there are problems.
+    ///
+    /// Requires root, otherwise every memory address will be zero
+    pub fn new() -> ProcResult<Vec<PhysicalMemoryMap>> {
+        let f = FileWrapper::open("/proc/iomem")?;
+
+        IoMem::from_reader(f)
+    }
+
+    /// Get Meminfo from a custom Read instead of the default `/proc/iomem`.
+    pub fn from_reader<R: io::Read>(r: R) -> ProcResult<Vec<PhysicalMemoryMap>> {
+        use std::io::{BufRead, BufReader};
+
+        let reader = BufReader::new(r);
+        let mut vec = Vec::new();
+
+        for line in reader.lines() {
+            let line = expect!(line);
+
+            let map = PhysicalMemoryMap::from_line(&line)?;
+
+            vec.push(map);
+        }
+
+        Ok(vec)
+    }
+}
+
+/// To construct this structure, see [crate::IoMem::new].
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+pub struct PhysicalMemoryMap {
+    /// The address space in the process that the mapping occupies.
+    pub address: (u64, u64),
+    pub name: String,
+}
+
+impl PhysicalMemoryMap {
+    fn from_line(line: &str) -> ProcResult<PhysicalMemoryMap> {
+        let line = line.trim();
+        let mut s = line.split(" : ");
+        let address = expect!(s.next());
+        let name = expect!(s.next());
+
+        Ok(PhysicalMemoryMap {
+            address: split_into_num(address, '-', 16)?,
+            name: String::from(name),
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,9 @@ pub mod keyring;
 mod uptime;
 pub use uptime::*;
 
+mod iomem;
+pub use iomem::*;
+
 lazy_static! {
     /// The number of clock ticks per second.
     ///

--- a/support.md
+++ b/support.md
@@ -81,7 +81,7 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
 * [ ] `/proc/fs`
 * [ ] `/proc/ide`
 * [ ] `/proc/interrupts`
-* [ ] `/proc/iomem`
+* [x] `/proc/iomem`
 * [ ] `/proc/ioports`
 * [ ] `/proc/kallsyms`
 * [ ] `/proc/kcore`


### PR DESCRIPTION
Hi,

This PR adds support for parsing `/proc/iomem`

The content looks like:

```
00100000-dffeffff : System RAM
  49200000-4a202387 : Kernel code
  4a400000-4b00bfff : Kernel rodata
  4b200000-4b7f503f : Kernel data
  4bfdb000-4c5fffff : Kernel bss
  c3000000-deffffff : Crash kernel
dfff0000-dfffffff : ACPI Tables
e0000000-fdffffff : PCI Bus 0000:00
  e0000000-e0ffffff : 0000:00:02.0
```

Some values are constant like `System RAM`, `Kernel code`... but others depend on the hardware and kernel modules: `vmwgfx probe`, `PCI Bus xxxx`...

Should we try to enumerate all of these in an enum like `MMapPath`, with a special variant holding a `String`?
Or we can keep it like this, with a simple `String`?

Another point is that this requires root or sudo, otherwise all addresses are 0. At first I added a `panic!` in the example, but I guess this would break CI?

What do you think?