### PR TITLE
pagemap / PFN example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -142,3 +142,13 @@ Lists all processes as a tree. Sub-processes will be hierarchically ordered bene
 ...
 ```
 
+## pfn.rs
+
+List memory mapping, and physical address for each virtual address. Must be run as root, see [pagemap.txt](https://github.com/torvalds/linux/blob/v4.9/Documentation/vm/pagemap.txt)
+
+```text
+Memory mapping MemoryMap { address: (140561525968896, 140561525972992), perms: "r--p", offset: 884736, dev: (252, 0), inode: 18221539, pathname: Path("/usr/lib64/libm.so.6") }
+virt_mem: 0x7fd707d31000, pfn: 0x1fd37d, phys_addr: 0x1fd37d000
+Memory mapping MemoryMap { address: (140561525972992, 140561525977088), perms: "rw-p", offset: 888832, dev: (252, 0), inode: 18221539, pathname: Path("/usr/lib64/libm.so.6") }
+virt_mem: 0x7fd707d32000, pfn: 0x1fcb97, phys_addr: 0x1fcb97000
+```

--- a/examples/pfn.rs
+++ b/examples/pfn.rs
@@ -1,6 +1,12 @@
 //
-// Print physical memory location for each memory mapping
+// Print physical memory location for each page for each memory mapping
 // This requires CAP_SYS_ADMIN privilege, or root, otherwise physical memory addresses will be zero
+//
+// Vocabulary
+// VA = Virtual Address: memory address from a process point of view
+// VPN = Virtual Page Number: page number of the a Virtual Memory address
+// PA = Physical Address: memory address in physical memory
+// PFN = Page Frame Number: page number of a Physical Address
 //
 
 use procfs::process::MMapPath;
@@ -19,11 +25,11 @@ fn main() {
     let mem_map = process.maps().unwrap();
 
     for memory_map in mem_map {
-        let mem_start = memory_map.address.0;
-        let mem_end = memory_map.address.1;
+        let va_start = memory_map.address.0;
+        let va_end = memory_map.address.1;
 
-        let index_start = (mem_start / page_size) as usize;
-        let index_end = (mem_end / page_size) as usize;
+        let vpn_start = (va_start / page_size) as usize;
+        let vpn_end = (va_end / page_size) as usize;
 
         // can't scan Vsyscall, so skip it
         if memory_map.pathname == MMapPath::Vsyscall {
@@ -32,17 +38,14 @@ fn main() {
 
         println!("Memory mapping {:?}", memory_map);
 
-        for index in index_start..index_end {
-            let virt_mem = index * page_size as usize;
-            let page_info = pagemap.get_info(index).unwrap();
+        for vpn in vpn_start..vpn_end {
+            let va = vpn * page_size as usize;
+            let page_info = pagemap.get_info(vpn).unwrap();
             match page_info {
                 procfs::process::PageInfo::MemoryPage(memory_page) => {
                     let pfn = memory_page.get_page_frame_number();
-                    let phys_addr = pfn * page_size;
-                    println!(
-                        "virt_mem: 0x{:x}, pfn: 0x{:x}, phys_addr: 0x{:x}",
-                        virt_mem, pfn, phys_addr
-                    );
+                    let pa = pfn * page_size;
+                    println!("virt_mem: 0x{:x}, pfn: 0x{:x}, phys_addr: 0x{:x}", va, pfn, pa);
                 }
                 procfs::process::PageInfo::SwapPage(_) => (), // page is in swap
             }

--- a/examples/pfn.rs
+++ b/examples/pfn.rs
@@ -1,0 +1,55 @@
+//
+// Print physical memory location for each memory mapping
+// This requires CAP_SYS_ADMIN privilege, or root, otherwise physical memory addresses will be zero
+//
+
+use procfs::process::MMapPath;
+use procfs::process::Process;
+
+fn main() {
+    if !rustix::process::geteuid().is_root() {
+        println!("WARNING: Access to /proc/<PID>/pagemap requires root, re-run with sudo");
+    }
+
+    let page_size = procfs::page_size().unwrap();
+
+    let process = Process::myself().expect("Unable to load myself!");
+
+    let mut pagemap = process.pagemap().unwrap();
+    let mem_map = process.maps().unwrap();
+
+    for memory_map in mem_map {
+        let mem_start = memory_map.address.0;
+        let mem_end = memory_map.address.1;
+
+        let index_start = (mem_start / page_size) as usize;
+        let index_end = (mem_end / page_size) as usize;
+
+        // can't scan Vsyscall, so skip it
+        if memory_map.pathname == MMapPath::Vsyscall {
+            continue;
+        }
+
+        println!("Memory mapping {:?}", memory_map);
+
+        for index in index_start..index_end {
+            let virt_mem = index * page_size as usize;
+            let page_info = pagemap.get_info(index).unwrap();
+            match page_info {
+                procfs::process::PageInfo::MemoryPage(memory_page) => {
+                    let pfn = memory_page.get_page_frame_number();
+                    let phys_addr = pfn * page_size;
+                    println!(
+                        "virt_mem: 0x{:x}, pfn: 0x{:x}, phys_addr: 0x{:x}",
+                        virt_mem, pfn, phys_addr
+                    );
+                }
+                procfs::process::PageInfo::SwapPage(_) => (), // page is in swap
+            }
+        }
+    }
+
+    if !rustix::process::geteuid().is_root() {
+        println!("\n\nWARNING: Access to /proc/<PID>/pagemap requires root, re-run with sudo");
+    }
+}

--- a/src/process/pagemap.rs
+++ b/src/process/pagemap.rs
@@ -117,6 +117,8 @@ impl PageMap {
     }
 
     /// Retrieves information in the page table entry for the page at index `page_index`.
+    ///
+    /// Some mappings are not accessible, and will return an Err: `vsyscall`
     pub fn get_info(&mut self, page_index: usize) -> ProcResult<PageInfo> {
         self.get_range_info(page_index..page_index + 1)
             .map(|mut vec| vec.pop().unwrap())


### PR DESCRIPTION
This example print physical memory location for each virtual memory mapping.

This requires root to work properly.