### PR TITLE
read dev and tcp files with specific pid #

### DIFF
--- a/examples/interface_stats.rs
+++ b/examples/interface_stats.rs
@@ -3,9 +3,11 @@
 fn main() {
     let delay = std::time::Duration::from_secs(2);
 
+    let mut cnt = 3;
+    println!("----- dev_status -----");
     let mut prev_stats = procfs::net::dev_status().unwrap();
     let mut prev_now = std::time::Instant::now();
-    loop {
+    while cnt > 0 {
         std::thread::sleep(delay);
         let now = std::time::Instant::now();
         let dev_stats = procfs::net::dev_status().unwrap();
@@ -34,8 +36,51 @@ fn main() {
                 (stat.sent_bytes - prev_stats.get(&stat.name).unwrap().sent_bytes) as f32 / dt / 1000.0
             );
         }
-
         prev_stats = dev_stats;
         prev_now = now;
+        cnt -= 1;
+    }
+
+    println!();
+    println!("================================================================================");
+    println!();
+
+    cnt = 3;
+    println!("----- dev_status_with_pid 1 -----");
+    let mut prev_stats_with_pid = procfs::net::dev_status_with_pid(1).unwrap();
+    let mut prev_now = std::time::Instant::now();
+    while cnt > 0 {
+        std::thread::sleep(delay);
+        let now = std::time::Instant::now();
+        let dev_stats_with_pid = procfs::net::dev_status_with_pid(1).unwrap();
+
+        // calculate diffs from previous
+        let dt = (now - prev_now).as_millis() as f32 / 1000.0;
+
+        let mut stats_with_pid: Vec<_> = dev_stats_with_pid.values().collect();
+        stats_with_pid.sort_by_key(|s| &s.name);
+        println!();
+        println!(
+            "{:>16}: {:<20}               {:<20} ",
+            "Interface", "bytes recv", "bytes sent"
+        );
+        println!(
+            "{:>16}  {:<20}               {:<20}",
+            "================", "====================", "===================="
+        );
+        for stat in stats_with_pid {
+            println!(
+                "{:>16}: {:<20}  {:>6.1} kbps  {:<20}  {:>6.1} kbps ",
+                stat.name,
+                stat.recv_bytes,
+                (stat.recv_bytes - prev_stats_with_pid.get(&stat.name).unwrap().recv_bytes) as f32 / dt / 1000.0,
+                stat.sent_bytes,
+                (stat.sent_bytes - prev_stats_with_pid.get(&stat.name).unwrap().sent_bytes) as f32 / dt / 1000.0
+            );
+        }
+
+        prev_stats_with_pid = dev_stats_with_pid;
+        prev_now = now;
+        cnt -= 1;
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -348,6 +348,20 @@ pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
     read_tcp_table(BufReader::new(file))
 }
 
+/// Reads the specific tcp socket table
+pub fn tcp_with_pid(pid: i32) -> ProcResult<Vec<TcpNetEntry>> {
+    let file = FileWrapper::open(format!("/proc/{}/net/tcp", pid))?;
+
+    read_tcp_table(BufReader::new(file))
+}
+
+/// Reads the specific tcp6 socket table
+pub fn tcp6_with_pid(pid: i32) -> ProcResult<Vec<TcpNetEntry>> {
+    let file = FileWrapper::open(format!("/proc/{}/net/tcp6", pid))?;
+
+    read_tcp_table(BufReader::new(file))
+}
+
 /// Reads the udp socket table
 pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
     let file = FileWrapper::open("/proc/net/udp")?;
@@ -630,6 +644,11 @@ impl DeviceStatus {
 /// example in the source repo.
 pub fn dev_status() -> ProcResult<HashMap<String, DeviceStatus>> {
     let file = FileWrapper::open("/proc/net/dev")?;
+    read_dev_status(file)
+}
+
+/// Returns basic network device statistics for all interfaces
+fn read_dev_status(file: FileWrapper) -> ProcResult<HashMap<String, DeviceStatus>> {
     let buf = BufReader::new(file);
     let mut map = HashMap::new();
     // the first two lines are headers, so skip them
@@ -639,6 +658,17 @@ pub fn dev_status() -> ProcResult<HashMap<String, DeviceStatus>> {
     }
 
     Ok(map)
+}
+
+/// Returns basic network device statistics for all interfaces
+///
+/// This data is from the `/proc/{pid}/net/dev` file.
+///
+/// For an example, see the [interface_stats.rs](https://github.com/eminence/procfs/tree/master/examples)
+/// example in the source repo.
+pub fn dev_status_with_pid(pid: i32) -> ProcResult<HashMap<String, DeviceStatus>> {
+    let file = FileWrapper::open(format!("/proc/{}/net/dev", pid))?;
+    read_dev_status(file)
 }
 
 /// An entry in the ipv4 route table


### PR DESCRIPTION
I have to write some kata-containers metrics interface, which will use the specific /proc/{pid}/net/tcp file. And some one has mentioned this problem one yeas ago. https://github.com/eminence/procfs/issues/126.

for some mistake, i had add `libc` package to reference `pid_t` type, but this pr i removed it, and test this function in `examples/interface_stats.rs`