### PR TITLE
Add new functions to read various net files for a specific process

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -335,6 +335,9 @@ pub fn read_udp_table<R: Read>(reader: BufReader<R>) -> ProcResult<Vec<UdpNetEnt
 }
 
 /// Reads the tcp socket table
+///
+/// Note that this is the socket table for the current progress.  If you want to
+/// see the socket table for another process, then see [Process::tcp()](crate::process::Process::tcp())
 pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
     let file = FileWrapper::open("/proc/net/tcp")?;
 
@@ -342,6 +345,9 @@ pub fn tcp() -> ProcResult<Vec<TcpNetEntry>> {
 }
 
 /// Reads the tcp6 socket table
+///
+/// Note that this is the socket table for the current progress.  If you want to
+/// see the socket table for another process, then see [Process::tcp6()](crate::process::Process::tcp6())
 pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
     let file = FileWrapper::open("/proc/net/tcp6")?;
 
@@ -349,6 +355,9 @@ pub fn tcp6() -> ProcResult<Vec<TcpNetEntry>> {
 }
 
 /// Reads the udp socket table
+///
+/// Note that this is the socket table for the current progress.  If you want to
+/// see the socket table for another process, then see [Process::udp()](crate::process::Process::udp())
 pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
     let file = FileWrapper::open("/proc/net/udp")?;
 
@@ -356,6 +365,9 @@ pub fn udp() -> ProcResult<Vec<UdpNetEntry>> {
 }
 
 /// Reads the udp6 socket table
+///
+/// Note that this is the socket table for the current progress.  If you want to
+/// see the socket table for another process, then see [Process::udp6()](crate::process::Process::udp6())
 pub fn udp6() -> ProcResult<Vec<UdpNetEntry>> {
     let file = FileWrapper::open("/proc/net/udp6")?;
 
@@ -363,8 +375,15 @@ pub fn udp6() -> ProcResult<Vec<UdpNetEntry>> {
 }
 
 /// Reads the unix socket table
+///
+/// Note that this is the socket table for the current progress.  If you want to
+/// see the socket table for another process, then see [Process::unix()](crate::process::Process::unix())
 pub fn unix() -> ProcResult<Vec<UnixNetEntry>> {
     let file = FileWrapper::open("/proc/net/unix")?;
+    unix_from_reader(file)
+}
+
+pub(crate) fn unix_from_reader(file: impl Read) -> ProcResult<Vec<UnixNetEntry>> {
     let reader = BufReader::new(file);
 
     let mut vec = Vec::new();
@@ -471,8 +490,14 @@ bitflags! {
 }
 
 /// Reads the ARP table
+///
+/// Note that this is the ARP table for the current progress.  If you want to
+/// see the ARP table for another process, then see [Process::arp()](crate::process::Process::arp())
 pub fn arp() -> ProcResult<Vec<ARPEntry>> {
     let file = FileWrapper::open("/proc/net/arp")?;
+    arp_from_reader(file)
+}
+pub(crate) fn arp_from_reader(file: impl Read) -> ProcResult<Vec<ARPEntry>> {
     let reader = BufReader::new(file);
 
     let mut vec = Vec::new();
@@ -628,8 +653,16 @@ impl DeviceStatus {
 ///
 /// For an example, see the [interface_stats.rs](https://github.com/eminence/procfs/tree/master/examples)
 /// example in the source repo.
+///
+/// Note that this returns information from the networking namespace of the
+/// current process.  If you want information for some otherr process, see
+/// [Process::dev_status()](crate::process::Process::dev_status())
 pub fn dev_status() -> ProcResult<HashMap<String, DeviceStatus>> {
     let file = FileWrapper::open("/proc/net/dev")?;
+
+    dev_status_from_reader(file)
+}
+pub(crate) fn dev_status_from_reader(file: impl Read) -> ProcResult<HashMap<String, DeviceStatus>> {
     let buf = BufReader::new(file);
     let mut map = HashMap::new();
     // the first two lines are headers, so skip them
@@ -669,8 +702,16 @@ pub struct RouteEntry {
 /// Reads the ipv4 route table
 ///
 /// This data is from the `/proc/net/route` file
+///
+/// Note that this returns information from the networking namespace of the
+/// current process.  If you want information for some other process, see
+/// [Process::route()](crate::process::Process::route())
 pub fn route() -> ProcResult<Vec<RouteEntry>> {
     let file = FileWrapper::open("/proc/net/route")?;
+    route_from_reader(file)
+}
+
+pub(crate) fn route_from_reader(file: impl Read) -> ProcResult<Vec<RouteEntry>> {
     let reader = BufReader::new(file);
 
     let mut vec = Vec::new();

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1400,6 +1400,35 @@ impl Process {
         read_udp_table(BufReader::new(file))
     }
 
+    /// Returns basic network device statistics for all interfaces in the process net namespace
+    ///
+    /// See also the [dev_status()](crate::net::dev_status()) function.
+    pub fn dev_status(&self) -> ProcResult<HashMap<String, net::DeviceStatus>> {
+        let file = FileWrapper::open_at(&self.root, &self.fd, "net/dev")?;
+
+        net::dev_status_from_reader(file)
+    }
+
+    /// Reads the unix socket table
+    pub fn unix(&self) -> ProcResult<Vec<net::UnixNetEntry>> {
+        let file = FileWrapper::open_at(&self.root, &self.fd, "net/unix")?;
+
+        net::unix_from_reader(file)
+    }
+
+    /// Reads the ARP table from the process net namespace
+    pub fn arp(&self) -> ProcResult<Vec<net::ARPEntry>> {
+        let file = FileWrapper::open_at(&self.root, &self.fd, "net/arp")?;
+
+        net::arp_from_reader(file)
+    }
+
+    /// Reads the ipv4 route table from the process net namespace
+    pub fn route(&self) -> ProcResult<Vec<net::RouteEntry>> {
+        let file = FileWrapper::open_at(&self.root, &self.fd, "net/route")?;
+        net::route_from_reader(file)
+    }
+
     /// Opens a file to the process's memory (`/proc/<pid>/mem`).
     ///
     /// Note: you cannot start reading from the start of the file.  You must first seek to

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use super::{FileWrapper, Io, Schedstat, Stat, Status};
 use crate::{ProcError, ProcResult};
-use rustix::fd::{OwnedFd, BorrowedFd};
+use rustix::fd::{BorrowedFd, OwnedFd};
 
 /// A task (aka Thread) inside of a [`Process`](crate::process::Process)
 ///

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -499,3 +499,16 @@ fn test_fdtarget_memfd() {
     let memfd = FDTarget::from_str("/memfd:test").unwrap();
     assert!(matches!(memfd, FDTarget::MemFD(s) if s == "test"));
 }
+
+#[test]
+fn test_network_stuff() {
+    let myself = Process::myself().unwrap();
+    let _tcp = myself.tcp().unwrap();
+    let _tcp6 = myself.tcp().unwrap();
+    let _udp = myself.udp().unwrap();
+    let _udp6 = myself.udp6().unwrap();
+    let _arp = myself.arp().unwrap();
+    let _route = myself.route().unwrap();
+    let _dev = myself.dev_status().unwrap();
+    let _unix = myself.unix().unwrap();
+}


### PR DESCRIPTION
The functions in the `net` module all read from the `/proc/net` symlink, which always points to the current process.

These new functions read from `/proc/pid/net`

Closes #126
Supersedes #218