### PR TITLE
Enable oppportunistic fd counting fast path

### DIFF
--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -337,6 +337,33 @@ fn test_proc_fds() {
 }
 
 #[test]
+fn test_proc_fd_count_runsinglethread() {
+    let myself = Process::myself().unwrap();
+
+    let before = myself.fd_count().unwrap();
+
+    let one = File::open("/proc/self").unwrap();
+    let two = File::open("/proc/self/status").unwrap();
+
+    let after = myself.fd_count().unwrap();
+
+    assert_eq!(
+        before + 2,
+        after,
+        "opened two files and expected {} open fds, saw {}",
+        before + 2,
+        after
+    );
+
+    drop(one);
+    drop(two);
+
+    let after_closing = myself.fd_count().unwrap();
+
+    assert_eq!(before, after_closing);
+}
+
+#[test]
 fn test_proc_fd() {
     let myself = Process::myself().unwrap();
     let raw_fd = myself.fd().unwrap().next().unwrap().unwrap().fd as i32;


### PR DESCRIPTION
Existing slow path takes ~52000us of CPU time on my laptop to count 100k open files. Compare this to just 13us for the baseline, when no extra files are open by a program:

```
fd count = 7, elapsed = 13 us
fd count = 100007, elapsed = 51863 us
```

Adding fastpath from Linux v6.2 makes it fast:

```
fd count = 4, elapsed = 2 us
fd count = 100004, elapsed = 8 us
```

This is before taking in account any lock contention effects in the kernel if you try to count files from multiple threads concurrently, which makes the slow path even slower, burning a lot more CPU in the process. See:

* https://github.com/torvalds/linux/commit/f1f1f2569901

I used the following code to benchmark:

```rust
use procfs::process::Process;
use std::{fs::File, time::Instant};

fn main() {
    let myself = Process::myself().unwrap();

    let started = Instant::now();
    let count = myself.fd_count().unwrap();
    let elapsed_us = started.elapsed().as_micros();

    eprintln!("fd count = {}, elapsed = {} us", count, elapsed_us);

    let files = (0..100_000)
        .map(|_| File::open("/etc/hosts").unwrap())
        .collect::<Vec<_>>();

    let started = Instant::now();
    let count = myself.fd_count().unwrap();
    let elapsed_us = started.elapsed().as_micros();

    eprintln!("fd count = {}, elapsed = {} us", count, elapsed_us);

    drop(files);
}
```

See also: https://github.com/prometheus/procfs/pull/486