### PR TITLE
ticks_per_second and page_size are infallible

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -13,5 +13,5 @@ fn main() {
 
     let stat = prc.stat().unwrap();
     println!("State: {:?}", stat.state());
-    println!("RSS:   {} bytes", stat.rss_bytes().unwrap());
+    println!("RSS:   {} bytes", stat.rss_bytes());
 }

--- a/examples/pfn.rs
+++ b/examples/pfn.rs
@@ -17,7 +17,7 @@ fn main() {
         println!("WARNING: Access to /proc/<PID>/pagemap requires root, re-run with sudo");
     }
 
-    let page_size = procfs::page_size().unwrap();
+    let page_size = procfs::page_size();
 
     let process = Process::myself().expect("Unable to load myself!");
 

--- a/examples/process_kpageflags.rs
+++ b/examples/process_kpageflags.rs
@@ -22,7 +22,7 @@ fn main() {
         panic!("ERROR: Access to /proc/kpageflags requires root, re-run with sudo");
     }
 
-    let page_size = procfs::page_size().unwrap();
+    let page_size = procfs::page_size();
 
     // We will inspect this process's own memory
     let process = Process::myself().expect("Unable to load myself!");

--- a/examples/ps.rs
+++ b/examples/ps.rs
@@ -7,7 +7,7 @@ extern crate procfs;
 
 fn main() {
     let mestat = procfs::process::Process::myself().unwrap().stat().unwrap();
-    let tps = procfs::ticks_per_second().unwrap();
+    let tps = procfs::ticks_per_second();
 
     println!("{: >10} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 

--- a/examples/self_memory.rs
+++ b/examples/self_memory.rs
@@ -4,7 +4,7 @@ fn main() {
     let me = Process::myself().expect("Unable to load myself!");
     println!("PID: {}", me.pid);
 
-    let page_size = procfs::page_size().expect("Unable to determinte page size!") as u64;
+    let page_size = procfs::page_size();
     println!("Memory page size: {}", page_size);
 
     // Note: when comparing the below values to what "top" will display, note that "top" will use
@@ -16,7 +16,7 @@ fn main() {
         println!(
             "Total resident set: {} pages ({} bytes)",
             stat.rss,
-            stat.rss as u64 * page_size
+            stat.rss * page_size
         );
         println!();
     }

--- a/src/kpageflags.rs
+++ b/src/kpageflags.rs
@@ -137,7 +137,7 @@ impl KPageFlags {
         let end = match page_range.end_bound() {
             Bound::Included(v) => *v + 1,
             Bound::Excluded(v) => *v,
-            Bound::Unbounded => std::u64::MAX / crate::page_size().unwrap(),
+            Bound::Unbounded => std::u64::MAX / crate::page_size(),
         };
 
         let start_position = start * size_of::<u64>() as u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,8 +298,8 @@ lazy_static! {
     /// The number of clock ticks per second.
     ///
     /// This is calculated from `sysconf(_SC_CLK_TCK)`.
-    static ref TICKS_PER_SECOND: ProcResult<u64> = {
-        Ok(ticks_per_second()?)
+    static ref TICKS_PER_SECOND: u64 = {
+        ticks_per_second()
     };
     /// The version of the currently running kernel.
     ///
@@ -311,8 +311,8 @@ lazy_static! {
     /// Memory page size, in bytes.
     ///
     /// This is calculated from `sysconf(_SC_PAGESIZE)`.
-    static ref PAGESIZE: ProcResult<u64> = {
-        Ok(page_size()?)
+    static ref PAGESIZE: u64 = {
+        page_size()
     };
 }
 
@@ -638,12 +638,8 @@ impl LoadAverage {
 ///
 /// This isn't part of the proc file system, but it's a useful thing to have, since several fields
 /// count in ticks.  This is calculated from `sysconf(_SC_CLK_TCK)`.
-pub fn ticks_per_second() -> std::io::Result<u64> {
-    if cfg!(unix) {
-        Ok(rustix::param::clock_ticks_per_second())
-    } else {
-        panic!("Not supported on non-unix platforms")
-    }
+pub fn ticks_per_second() -> u64 {
+    rustix::param::clock_ticks_per_second()
 }
 
 /// The boot time of the system, as a `DateTime` object.
@@ -693,12 +689,8 @@ thread_local! {
 /// Memory page size, in bytes.
 ///
 /// This is calculated from `sysconf(_SC_PAGESIZE)`.
-pub fn page_size() -> std::io::Result<u64> {
-    if cfg!(unix) {
-        Ok(rustix::param::page_size() as u64)
-    } else {
-        panic!("Not supported on non-unix platforms")
-    }
+pub fn page_size() -> u64 {
+    rustix::param::page_size() as u64
 }
 
 /// Possible values for a kernel config option
@@ -837,7 +829,7 @@ impl CpuTime {
 
         // Store this field in the struct so we don't have to attempt to unwrap ticks_per_second() when we convert
         // from ticks into other time units
-        let tps = crate::ticks_per_second()?;
+        let tps = crate::ticks_per_second();
 
         s.next();
         let user = from_str!(u64, expect!(s.next()));
@@ -1385,7 +1377,7 @@ mod tests {
 
     #[test]
     fn tests_tps() {
-        let tps = ticks_per_second().unwrap();
+        let tps = ticks_per_second();
         println!("{} ticks per second", tps);
     }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -19,7 +19,7 @@
 //! ```rust
 //! let me = procfs::process::Process::myself().unwrap();
 //! let me_stat = me.stat().unwrap();
-//! let tps = procfs::ticks_per_second().unwrap();
+//! let tps = procfs::ticks_per_second();
 //!
 //! println!("{: >10} {: <8} {: >8} {}", "PID", "TTY", "TIME", "CMD");
 //!
@@ -49,7 +49,7 @@
 //! # use procfs::process::Process;
 //! let me = Process::myself().unwrap();
 //! let me_stat = me.stat().unwrap();
-//! let page_size = procfs::page_size().unwrap() as u64;
+//! let page_size = procfs::page_size();
 //!
 //! println!("== Data from /proc/self/stat:");
 //! println!("Total virtual memory used: {} bytes", me_stat.vsize);

--- a/src/process/pagemap.rs
+++ b/src/process/pagemap.rs
@@ -137,7 +137,7 @@ impl PageMap {
         let end = match page_range.end_bound() {
             Bound::Included(v) => *v + 1,
             Bound::Excluded(v) => *v,
-            Bound::Unbounded => std::usize::MAX / crate::page_size().unwrap() as usize,
+            Bound::Unbounded => std::usize::MAX / crate::page_size() as usize,
         };
 
         let start_position = (start * size_of::<u64>()) as u64;

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -405,10 +405,7 @@ impl Stat {
     /// This function requires the "chrono" features to be enabled (which it is by default).
     #[cfg(feature = "chrono")]
     pub fn starttime(&self) -> ProcResult<chrono::DateTime<chrono::Local>> {
-        let tts = TICKS_PER_SECOND
-            .as_ref()
-            .map_err(|e| ProcError::Other(format!("Failed to get ticks_per_second: {:?}", e)))?;
-        let seconds_since_boot = self.starttime as f32 / *tts as f32;
+        let seconds_since_boot = self.starttime as f32 / *TICKS_PER_SECOND as f32;
         let boot_time = crate::boot_time()?;
 
         Ok(boot_time + chrono::Duration::milliseconds((seconds_since_boot * 1000.0) as i64))
@@ -417,10 +414,7 @@ impl Stat {
     /// Gets the Resident Set Size (in bytes)
     ///
     /// The `rss` field will return the same value in pages
-    pub fn rss_bytes(&self) -> ProcResult<u64> {
-        let pagesize = PAGESIZE
-            .as_ref()
-            .map_err(|e| ProcError::Other(format!("Failed to get pagesize: {:?}", e)))?;
-        Ok(self.rss * *pagesize)
+    pub fn rss_bytes(&self) -> u64 {
+        self.rss * *PAGESIZE
     }
 }

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -143,7 +143,7 @@ mod tests {
                 assert_eq!(vec.len(), bytes_to_read as usize);
 
                 // spin for about 52 ticks (utime accounting isn't perfectly accurate)
-                let dur = std::time::Duration::from_millis(52 * (1000 / crate::ticks_per_second().unwrap()) as u64);
+                let dur = std::time::Duration::from_millis(52 * (1000 / crate::ticks_per_second()) as u64);
                 let start = std::time::Instant::now();
                 while start.elapsed() <= dur {
                     // spin

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -296,7 +296,7 @@ fn test_proc_pagemap() {
     let maps = myself.maps().unwrap();
 
     let stack_map = maps.iter().find(|m| matches!(m.pathname, MMapPath::Stack)).unwrap();
-    let page_size = crate::page_size().unwrap() as usize;
+    let page_size = crate::page_size() as usize;
     let start_page = stack_map.address.0 as usize / page_size;
     let end_page = stack_map.address.1 as usize / page_size;
 
@@ -427,7 +427,7 @@ fn test_proc_auxv() {
             16 => println!("HW Cap: 0x{:x}", v),
             17 => {
                 println!("Clock ticks per second: {}", v);
-                assert_eq!(v, crate::ticks_per_second().unwrap());
+                assert_eq!(v, crate::ticks_per_second());
             }
             19 => println!("Data cache block size: {}", v),
             23 => println!("Run as setuid?: {}", v),


### PR DESCRIPTION
These functions used to be fallible, but aren't any more.   So they can
directly return a u64, instead of a Result