### PR TITLE
Refactor and expose memory map processing.

### DIFF
--- a/examples/shm.rs
+++ b/examples/shm.rs
@@ -13,7 +13,7 @@ fn main() {
             let prc = prc.unwrap();
             match prc.smaps() {
                 Ok(memory_maps) => {
-                    for (memory_map, _memory_map_data) in &memory_maps {
+                    for memory_map in &memory_maps {
                         if let procfs::process::MMapPath::Vsys(key) = memory_map.pathname {
                             if key == shared_memory.key && memory_map.inode == shared_memory.shmid {
                                 println!("{}: {:?}", prc.pid, prc.cmdline().unwrap());

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -553,8 +553,8 @@ impl MemoryMaps {
 
                             let flags = flags
                                 .map(VmFlags::from_str)
-                                .reduce(std::ops::BitOr::bitor)
-                                .unwrap_or_default();
+                                // FUTURE: use `Iterator::reduce`
+                                .fold(VmFlags::NONE, std::ops::BitOr::bitor);
 
                             mm.extension.vm_flags = flags;
                         } else {

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -207,10 +207,11 @@ bitflags! {
 bitflags! {
     /// Represents the kernel flags associated with the virtual memory area.
     /// The names of these flags are just those you'll find in the man page, but in upper case.
+    #[derive(Default)]
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
     pub struct VmFlags: u32 {
-        /// Invalid flags
-        const INVALID = 0;
+        /// No flags
+        const NONE = 0;
         /// Readable
         const RD = 1 << 0;
         /// Writable
@@ -279,45 +280,45 @@ bitflags! {
 }
 
 impl VmFlags {
-    fn from_str(flag: &str) -> Option<Self> {
+    fn from_str(flag: &str) -> Self {
         if flag.len() != 2 {
-            return None;
+            return VmFlags::NONE;
         }
 
         match flag {
-            "rd" => Some(VmFlags::RD),
-            "wr" => Some(VmFlags::WR),
-            "ex" => Some(VmFlags::EX),
-            "sh" => Some(VmFlags::SH),
-            "mr" => Some(VmFlags::MR),
-            "mw" => Some(VmFlags::MW),
-            "me" => Some(VmFlags::ME),
-            "ms" => Some(VmFlags::MS),
-            "gd" => Some(VmFlags::GD),
-            "pf" => Some(VmFlags::PF),
-            "dw" => Some(VmFlags::DW),
-            "lo" => Some(VmFlags::LO),
-            "io" => Some(VmFlags::IO),
-            "sr" => Some(VmFlags::SR),
-            "rr" => Some(VmFlags::RR),
-            "dc" => Some(VmFlags::DC),
-            "de" => Some(VmFlags::DE),
-            "ac" => Some(VmFlags::AC),
-            "nr" => Some(VmFlags::NR),
-            "ht" => Some(VmFlags::HT),
-            "sf" => Some(VmFlags::SF),
-            "nl" => Some(VmFlags::NL),
-            "ar" => Some(VmFlags::AR),
-            "wf" => Some(VmFlags::WF),
-            "dd" => Some(VmFlags::DD),
-            "sd" => Some(VmFlags::SD),
-            "mm" => Some(VmFlags::MM),
-            "hg" => Some(VmFlags::HG),
-            "nh" => Some(VmFlags::NH),
-            "mg" => Some(VmFlags::MG),
-            "um" => Some(VmFlags::UM),
-            "uw" => Some(VmFlags::UW),
-            _ => None,
+            "rd" => VmFlags::RD,
+            "wr" => VmFlags::WR,
+            "ex" => VmFlags::EX,
+            "sh" => VmFlags::SH,
+            "mr" => VmFlags::MR,
+            "mw" => VmFlags::MW,
+            "me" => VmFlags::ME,
+            "ms" => VmFlags::MS,
+            "gd" => VmFlags::GD,
+            "pf" => VmFlags::PF,
+            "dw" => VmFlags::DW,
+            "lo" => VmFlags::LO,
+            "io" => VmFlags::IO,
+            "sr" => VmFlags::SR,
+            "rr" => VmFlags::RR,
+            "dc" => VmFlags::DC,
+            "de" => VmFlags::DE,
+            "ac" => VmFlags::AC,
+            "nr" => VmFlags::NR,
+            "ht" => VmFlags::HT,
+            "sf" => VmFlags::SF,
+            "nl" => VmFlags::NL,
+            "ar" => VmFlags::AR,
+            "wf" => VmFlags::WF,
+            "dd" => VmFlags::DD,
+            "sd" => VmFlags::SD,
+            "mm" => VmFlags::MM,
+            "hg" => VmFlags::HG,
+            "nh" => VmFlags::NH,
+            "mg" => VmFlags::MG,
+            "um" => VmFlags::UM,
+            "uw" => VmFlags::UW,
+            _ => VmFlags::NONE,
         }
     }
 }
@@ -476,6 +477,8 @@ pub enum MMapPath {
     Vvar,
     /// obsolete virtual syscalls, succeeded by vdso
     Vsyscall,
+    /// rollup memory mappings, from `/proc/<pid>/smaps_rollup`
+    Rollup,
     /// An anonymous mapping as obtained via mmap(2).
     Anonymous,
     /// Shared memory segment
@@ -485,11 +488,6 @@ pub enum MMapPath {
 }
 
 impl MMapPath {
-    /// Needed for MemoryMap::new().
-    fn new() -> MMapPath {
-        MMapPath::Anonymous
-    }
-
     fn from(path: &str) -> ProcResult<MMapPath> {
         Ok(match path.trim() {
             "" => MMapPath::Anonymous,
@@ -498,6 +496,7 @@ impl MMapPath {
             "[vdso]" => MMapPath::Vdso,
             "[vvar]" => MMapPath::Vvar,
             "[vsyscall]" => MMapPath::Vsyscall,
+            "[rollup]" => MMapPath::Rollup,
             x if x.starts_with("[stack:") => {
                 let mut s = x[1..x.len() - 1].split(':');
                 let tid = from_str!(u32, expect!(s.nth(1)));
@@ -510,10 +509,120 @@ impl MMapPath {
     }
 }
 
-/// Represents an entry in a `/proc/<pid>/maps` file.
+/// Represents all entries in a `/proc/<pid>/maps` or `/proc/<pid>/smaps` file.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+pub struct MemoryMaps {
+    pub memory_maps: Vec<MemoryMap>,
+}
+
+impl MemoryMaps {
+    pub fn from_reader<R: io::Read>(r: R) -> ProcResult<Self> {
+        Self::read(r, None)
+    }
+
+    pub fn from_path<P: AsRef<Path>>(path: P) -> ProcResult<Self> {
+        let file = FileWrapper::open(path.as_ref())?;
+        Self::read(file, Some(path.as_ref()))
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<MemoryMap> {
+        self.memory_maps.iter()
+    }
+
+    fn read<R: io::Read>(r: R, path: Option<&Path>) -> ProcResult<Self> {
+        let reader = BufReader::new(r);
+
+        let mut memory_maps = Vec::new();
+
+        let mut line_iter = reader
+            .lines()
+            .map(|r| r.map_err(|_| ProcError::Incomplete(path.map(ToOwned::to_owned))));
+        let mut current_memory_map: Option<MemoryMap> = None;
+        while let Some(line) = line_iter.next().transpose()? {
+            // Assumes all extension fields (in `/proc/<pid>/smaps`) start with a capital letter,
+            // which seems to be the case.
+            if line.starts_with(|c: char| c.is_ascii_uppercase()) {
+                match current_memory_map.as_mut() {
+                    None => return Err(ProcError::Incomplete(path.map(ToOwned::to_owned))),
+                    Some(mm) => {
+                        // This is probably an attribute
+                        if line.starts_with("VmFlags") {
+                            let flags = line.split_ascii_whitespace();
+                            let flags = flags.skip(1); // Skips the `VmFlags:` part since we don't need it.
+
+                            let flags = flags
+                                .map(VmFlags::from_str)
+                                .reduce(std::ops::BitOr::bitor)
+                                .unwrap_or_default();
+
+                            mm.extension.vm_flags = flags;
+                        } else {
+                            let mut parts = line.split_ascii_whitespace();
+
+                            let key = parts.next();
+                            let value = parts.next();
+
+                            if let (Some(k), Some(v)) = (key, value) {
+                                // While most entries do have one, not all of them do.
+                                let size_suffix = parts.next();
+
+                                // Limited poking at /proc/<pid>/smaps and then checking if "MB", "GB", and "TB" appear in the C file that is
+                                // supposedly responsible for creating smaps, has lead me to believe that the only size suffixes we'll ever encounter
+                                // "kB", which is most likely kibibytes. Actually checking if the size suffix is any of the above is a way to
+                                // future-proof the code, but I am not sure it is worth doing so.
+                                let size_multiplier = if size_suffix.is_some() { 1024 } else { 1 };
+
+                                let v = v.parse::<u64>().map_err(|_| {
+                                    ProcError::Other("Value in `Key: Value` pair was not actually a number".into())
+                                })?;
+
+                                // This ignores the case when our Key: Value pairs are really Key Value pairs. Is this a good idea?
+                                let k = k.trim_end_matches(':');
+
+                                mm.extension.map.insert(k.into(), v * size_multiplier);
+                            }
+                        }
+                    }
+                }
+            } else {
+                if let Some(mm) = current_memory_map.take() {
+                    memory_maps.push(mm);
+                }
+                current_memory_map = Some(MemoryMap::from_line(&line)?);
+            }
+        }
+        if let Some(mm) = current_memory_map.take() {
+            memory_maps.push(mm);
+        }
+
+        Ok(MemoryMaps { memory_maps })
+    }
+}
+
+impl<'a> IntoIterator for &'a MemoryMaps {
+    type IntoIter = std::slice::Iter<'a, MemoryMap>;
+    type Item = &'a MemoryMap;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for MemoryMaps {
+    type IntoIter = std::vec::IntoIter<MemoryMap>;
+    type Item = MemoryMap;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.memory_maps.into_iter()
+    }
+}
+
+/// Represents an entry in a `/proc/<pid>/maps` or `/proc/<pid>/smaps` file.
 ///
-/// To construct this structure, see [Process::maps()] and [Process::smaps()].
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+/// To construct this structure for the current process, see [Process::maps()] and
+/// [Process::smaps()].
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct MemoryMap {
     /// The address space in the process that the mapping occupies.
@@ -529,20 +638,13 @@ pub struct MemoryMap {
     /// BSS (uninitialized data).
     pub inode: u64,
     pub pathname: MMapPath,
+    /// Memory mapping extension information, populated when parsing `/proc/<pid>/smaps`.
+    ///
+    /// The members will be `Default::default()` (empty/none) when the information isn't available.
+    pub extension: MMapExtension,
 }
 
 impl MemoryMap {
-    /// Used internally in Process::smaps() as a "default value" thing
-    fn new() -> Self {
-        Self {
-            address: (0, 0),
-            perms: "".into(),
-            offset: 0,
-            dev: (0, 0),
-            inode: 0,
-            pathname: MMapPath::new(),
-        }
-    }
     fn from_line(line: &str) -> ProcResult<MemoryMap> {
         let mut s = line.splitn(6, ' ');
         let address = expect!(s.next());
@@ -559,6 +661,7 @@ impl MemoryMap {
             dev: split_into_num(dev, ':', 16)?,
             inode: from_str!(u64, inode),
             pathname: MMapPath::from(path)?,
+            extension: Default::default(),
         })
     }
 }
@@ -566,20 +669,20 @@ impl MemoryMap {
 /// Represents the information about a specific mapping as presented in /proc/\<pid\>/smaps
 ///
 /// To construct this structure, see [Process::smaps()]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-pub struct MemoryMapData {
-    /// Key-Value pairs that may represent statistics about memory usage, or other interesting things,
-    /// such a "ProtectionKey"(if you're on X86 and that kernel config option was specified).
+pub struct MMapExtension {
+    /// Key-value pairs that may represent statistics about memory usage, or other interesting things,
+    /// such a "ProtectionKey" (if you're on X86 and that kernel config option was specified).
     ///
-    /// Note that should a Key-Value pair represent a memory usage statistic, it will be in bytes.
+    /// Note that should a key-value pair represent a memory usage statistic, it will be in bytes.
     ///
     /// Check your manpage for more information
     pub map: HashMap<String, u64>,
     /// Kernel flags associated with the virtual memory area
     ///
     /// (since Linux 3.8)
-    pub vm_flags: Option<VmFlags>,
+    pub vm_flags: VmFlags,
 }
 
 impl Io {
@@ -983,85 +1086,16 @@ impl Process {
 
     /// Return a list of the currently mapped memory regions and their access permissions, based on
     /// the `/proc/pid/maps` file.
-    pub fn maps(&self) -> ProcResult<Vec<MemoryMap>> {
-        let file = FileWrapper::open_at(&self.root, &self.fd, "maps")?;
-
-        let reader = BufReader::new(file);
-
-        let mut vec = Vec::new();
-
-        for line in reader.lines() {
-            let line = line.map_err(|_| ProcError::Incomplete(Some(self.root.join("maps"))))?;
-            vec.push(MemoryMap::from_line(&line)?);
-        }
-
-        Ok(vec)
+    pub fn maps(&self) -> ProcResult<MemoryMaps> {
+        MemoryMaps::from_path(self.root.join("maps"))
     }
 
     /// Returns a list of currently mapped memory regions and verbose information about them,
     /// such as memory consumption per mapping, based on the `/proc/pid/smaps` file.
     ///
     /// (since Linux 2.6.14 and requires CONFIG_PROG_PAGE_MONITOR)
-    pub fn smaps(&self) -> ProcResult<Vec<(MemoryMap, MemoryMapData)>> {
-        let file = FileWrapper::open_at(&self.root, &self.fd, "smaps")?;
-
-        let reader = BufReader::new(file);
-
-        let mut vec: Vec<(MemoryMap, MemoryMapData)> = Vec::new();
-
-        let mut current_mapping = MemoryMap::new();
-        let mut current_data = Default::default();
-        for line in reader.lines() {
-            let line = line.map_err(|_| ProcError::Incomplete(Some(self.root.join("smaps"))))?;
-
-            if let Ok(mapping) = MemoryMap::from_line(&line) {
-                vec.push((current_mapping, current_data));
-                current_mapping = mapping;
-                current_data = Default::default();
-            } else {
-                // This is probably an attribute
-                if line.starts_with("VmFlags") {
-                    let flags = line.split_ascii_whitespace();
-                    let flags = flags.skip(1); // Skips the `VmFlags:` part since we don't need it.
-
-                    let flags = flags
-                        .map(|v| match VmFlags::from_str(v) {
-                            None => VmFlags::INVALID,
-                            Some(v) => v,
-                        })
-                        .fold(VmFlags::INVALID, |a, b| a | b);
-
-                    current_data.vm_flags = Some(flags);
-                } else {
-                    let mut parts = line.split_ascii_whitespace();
-
-                    let key = parts.next();
-                    let value = parts.next();
-
-                    if let (Some(k), Some(v)) = (key, value) {
-                        // While most entries do have one, not all of them do.
-                        let size_suffix = parts.next();
-
-                        // Limited poking at /proc/<pid>/smaps and then checking if "MB", "GB", and "TB" appear in the C file that is
-                        // supposedly responsible for creating smaps, has lead me to believe that the only size suffixes we'll ever encounter
-                        // "kB", which is most likely kibibytes. Actually checking if the size suffix is any of the above is a way to
-                        // future-proof the code, but I am not sure it is worth doing so.
-                        let size_multiplier = if size_suffix.is_some() { 1024 } else { 1 };
-
-                        let v = v.parse::<u64>().map_err(|_| {
-                            ProcError::Other("Value in `Key: Value` pair was not actually a number".into())
-                        })?;
-
-                        // This ignores the case when our Key: Value pairs are really Key Value pairs. Is this a good idea?
-                        let k = k.trim_end_matches(':');
-
-                        current_data.map.insert(k.into(), v * size_multiplier);
-                    }
-                }
-            }
-        }
-
-        Ok(vec)
+    pub fn smaps(&self) -> ProcResult<MemoryMaps> {
+        MemoryMaps::from_path(self.root.join("smaps"))
     }
 
     /// This is the sum of all the smaps data but it is much more performant to get it this way.

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -560,6 +560,7 @@ impl MMapPath {
 /// Represents all entries in a `/proc/<pid>/maps` or `/proc/<pid>/smaps` file.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub struct MemoryMaps {
     pub memory_maps: Vec<MemoryMap>,
 }
@@ -731,6 +732,13 @@ pub struct MMapExtension {
     ///
     /// (since Linux 3.8)
     pub vm_flags: VmFlags,
+}
+
+impl MMapExtension {
+    /// Return whether the extension information is empty.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty() && self.vm_flags == VmFlags::NONE
+    }
 }
 
 impl Io {

--- a/src/process/smaps_rollup.rs
+++ b/src/process/smaps_rollup.rs
@@ -1,58 +1,14 @@
-use super::{MemoryMap, MemoryMapData};
-use crate::{ProcError, ProcResult};
-use std::io::{BufRead, BufReader, Read};
+use super::MemoryMaps;
+use crate::ProcResult;
+use std::io::Read;
 
 #[derive(Debug)]
 pub struct SmapsRollup {
-    pub memory_map: MemoryMap,
-    pub memory_map_data: MemoryMapData,
+    pub memory_map_rollup: MemoryMaps,
 }
 
 impl SmapsRollup {
-    // this implemenation is similar but not identical to Process::smaps()
     pub fn from_reader<R: Read>(r: R) -> ProcResult<SmapsRollup> {
-        let reader = BufReader::new(r);
-
-        let mut memory_map = MemoryMap::new();
-        let mut memory_map_data: MemoryMapData = Default::default();
-        let mut first = true;
-        for line in reader.lines() {
-            let line = line.map_err(|_| ProcError::Incomplete(None))?;
-
-            if first {
-                memory_map = MemoryMap::from_line(&line)?;
-                first = false;
-                continue;
-            }
-
-            let mut parts = line.split_ascii_whitespace();
-
-            let key = parts.next();
-            let value = parts.next();
-
-            if let (Some(k), Some(v)) = (key, value) {
-                // While most entries do have one, not all of them do.
-                let size_suffix = parts.next();
-
-                // Limited poking at /proc/<pid>/smaps and then checking if "MB", "GB", and "TB" appear in the C file that is
-                // supposedly responsible for creating smaps, has lead me to believe that the only size suffixes we'll ever encounter
-                // "kB", which is most likely kibibytes. Actually checking if the size suffix is any of the above is a way to
-                // future-proof the code, but I am not sure it is worth doing so.
-                let size_multiplier = if size_suffix.is_some() { 1024 } else { 1 };
-
-                let v = v
-                    .parse::<u64>()
-                    .map_err(|_| ProcError::Other("Value in `Key: Value` pair was not actually a number".into()))?;
-
-                // This ignores the case when our Key: Value pairs are really Key Value pairs. Is this a good idea?
-                let k = k.trim_end_matches(':');
-
-                memory_map_data.map.insert(k.into(), v * size_multiplier);
-            }
-        }
-        Ok(SmapsRollup {
-            memory_map,
-            memory_map_data,
-        })
+        MemoryMaps::from_reader(r).map(|m| SmapsRollup { memory_map_rollup: m })
     }
 }

--- a/src/process/stat.rs
+++ b/src/process/stat.rs
@@ -3,7 +3,7 @@ use super::StatFlags;
 #[cfg(feature = "chrono")]
 use crate::TICKS_PER_SECOND;
 use crate::{from_iter, KernelVersion, ProcResult};
-use crate::{ProcError, KERNEL, PAGESIZE};
+use crate::{KERNEL, PAGESIZE};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
A new MemoryMaps struct is added, which parses all of `maps`, `smaps`, and `smaps_rollup`.

Closes #236.