### PR TITLE
Turn PFN into a concrete type

### DIFF
--- a/examples/kpagecount.rs
+++ b/examples/kpagecount.rs
@@ -33,11 +33,10 @@ fn main() {
 
         // Physical memory is divided into pages of `page_size` bytes (usually 4kiB)
         // Each page is referenced by its Page Fram Number (PFN)
-        let start_pfn = map.address.0 / page_size;
-        let end_pfn = map.address.1 / page_size;
+        let (start_pfn, end_pfn) = map.get_range();
 
         let page_references = kpagecount
-            .get_count_in_range(start_pfn..end_pfn)
+            .get_count_in_range(start_pfn, end_pfn)
             .expect("Can't read from /proc/kpagecount");
 
         // find the page with most references

--- a/examples/pfn.rs
+++ b/examples/pfn.rs
@@ -44,10 +44,17 @@ fn main() {
             match page_info {
                 procfs::process::PageInfo::MemoryPage(memory_page) => {
                     let pfn = memory_page.get_page_frame_number();
-                    let pa = pfn * page_size;
+                    let pa = pfn.0 * page_size;
                     println!("virt_mem: 0x{:x}, pfn: 0x{:x}, phys_addr: 0x{:x}", va, pfn, pa);
                 }
-                procfs::process::PageInfo::SwapPage(_) => (), // page is in swap
+                procfs::process::PageInfo::SwapPage(swap_page_flags) => {
+                    let swap_type = swap_page_flags.get_swap_type();
+                    let swap_offset = swap_page_flags.get_swap_offset();
+                    println!(
+                        "virt_mem: 0x{:x}, swap: {:}, offset: 0x{:x}",
+                        va, swap_type, swap_offset
+                    );
+                }
             }
         }
     }

--- a/examples/process_kpageflags.rs
+++ b/examples/process_kpageflags.rs
@@ -77,7 +77,7 @@ fn main() {
             match page_info {
                 procfs::process::PageInfo::MemoryPage(memory_page) => {
                     let pfn = memory_page.get_page_frame_number();
-                    let phys_addr = pfn * page_size;
+                    let phys_addr = pfn.0 * page_size;
 
                     let physical_page_info = kpageflags.get_info(pfn).expect("Can't get kpageflags info");
 
@@ -86,7 +86,15 @@ fn main() {
                         virt_mem, pfn, phys_addr, physical_page_info
                     );
                 }
-                procfs::process::PageInfo::SwapPage(_) => (), // page is in swap
+                procfs::process::PageInfo::SwapPage(swap_page_flags) => {
+                    let swap_type = swap_page_flags.get_swap_type();
+                    let swap_offset = swap_page_flags.get_swap_offset();
+
+                    println!(
+                        "Found page\nvirt_mem: 0x{:x}, swap_type: {:}, swap_offset: 0x{:x}, flags: {:?}",
+                        virt_mem, swap_type, swap_offset, swap_page_flags
+                    );
+                }
             }
         }
     }

--- a/src/iomem.rs
+++ b/src/iomem.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
 
 use super::{FileWrapper, ProcResult};
-use crate::split_into_num;
+use crate::{process::Pfn, split_into_num};
 
 /// Reads and parses the `/proc/iomem`, returning an error if there are problems.
 ///
@@ -49,5 +49,16 @@ impl PhysicalMemoryMap {
                 name: String::from(name),
             },
         ))
+    }
+
+    /// Get the PFN range for the mapping
+    ///
+    /// First element of the tuple (start) is included.
+    /// Second element (end) is excluded
+    pub fn get_range(&self) -> (Pfn, Pfn) {
+        let start = self.address.0 / crate::page_size();
+        let end = (self.address.1 + 1) / crate::page_size();
+
+        (Pfn(start), Pfn(end))
     }
 }

--- a/src/kpagecount.rs
+++ b/src/kpagecount.rs
@@ -1,11 +1,10 @@
 use std::{
     io::{BufReader, Read, Seek, SeekFrom},
     mem::size_of,
-    ops::{Bound, Range, RangeBounds},
     path::Path,
 };
 
-use crate::FileWrapper;
+use crate::{process::Pfn, FileWrapper};
 
 use super::ProcResult;
 
@@ -41,40 +40,25 @@ impl KPageCount {
     /// Return Err if pfn is not in RAM. See [crate::iomem()] for a list of valid physical RAM addresses
     ///
     /// See [crate::process::Process::pagemap] and [crate::process::MemoryPageFlags::get_page_frame_number]
-    pub fn get_count_at_pfn(&mut self, pfn: u64) -> ProcResult<u64> {
-        self.get_count_in_range(pfn..pfn + 1).map(|mut vec| vec.pop().unwrap())
+    pub fn get_count_at_pfn(&mut self, pfn: Pfn) -> ProcResult<u64> {
+        self.get_count_in_range(pfn, Pfn(pfn.0 + 1))
+            .map(|mut vec| vec.pop().unwrap())
     }
 
-    /// Get the number of references to physical memory at for PFNs within range `page_range`
+    /// Get the number of references to physical memory at for PFNs within `start` and `end` PFNs, `end` is excluded
     ///
     /// Return Err if any pfn is not in RAM. See [crate::iomem()] for a list of valid physical RAM addresses
     ///
     /// See [crate::process::Process::pagemap] and [crate::process::MemoryPageFlags::get_page_frame_number]
-    pub fn get_count_in_range(&mut self, page_range: Range<u64>) -> ProcResult<Vec<u64>> {
-        // `start` is always included
-        let start = match page_range.start_bound() {
-            Bound::Included(v) => *v,
-            Bound::Excluded(v) => *v + 1,
-            Bound::Unbounded => 0,
-        };
+    pub fn get_count_in_range(&mut self, start: Pfn, end: Pfn) -> ProcResult<Vec<u64>> {
+        let mut result = Vec::with_capacity((end.0 - start.0) as usize);
 
-        // `end` is always excluded
-        let end = match page_range.end_bound() {
-            Bound::Included(v) => *v + 1,
-            Bound::Excluded(v) => *v,
-            Bound::Unbounded => std::u64::MAX,
-        };
-
-        let mut result: Vec<u64> = Vec::new();
-
-        let start_position = start * size_of::<u64>() as u64;
+        let start_position = start.0 * size_of::<u64>() as u64;
         self.reader.seek(SeekFrom::Start(start_position))?;
 
-        for _pfn in start..end {
+        for _pfn in start.0..end.0 {
             // Each entry is a 64 bits counter
-            // 64 bits or 8 Bytes
-            const ENTRY_SIZE: usize = 8;
-            let mut buf = [0; ENTRY_SIZE];
+            let mut buf = [0; size_of::<u64>()];
 
             self.reader.read_exact(&mut buf)?;
             let page_references: u64 = u64::from_le_bytes(buf);


### PR DESCRIPTION
Replace `u64` by a struct

I had to change some function signatures, because it is not possible to use `Range<Pfn>`.

I also removed the open bounds, but they didn't made any sense in the first place.