### PR TITLE
fix shm size type

### DIFF
--- a/src/sysvipc_shm.rs
+++ b/src/sysvipc_shm.rs
@@ -19,7 +19,7 @@ pub struct Shm {
     /// Access permissions, as octal
     pub perms: u16,
     /// Size in bytes
-    pub size: u32,
+    pub size: u64,
     /// Creator PID
     pub cpid: i32,
     /// Last operator PID
@@ -70,7 +70,7 @@ impl Shm {
             let key = expect!(i32::from_str(expect!(s.next())));
             let shmid = expect!(u64::from_str(expect!(s.next())));
             let perms = expect!(u16::from_str(expect!(s.next())));
-            let size = expect!(u32::from_str(expect!(s.next())));
+            let size = expect!(u64::from_str(expect!(s.next())));
             let cpid = expect!(i32::from_str(expect!(s.next())));
             let lpid = expect!(i32::from_str(expect!(s.next())));
             let nattch = expect!(u32::from_str(expect!(s.next())));


### PR DESCRIPTION
Seems like a made a mistake when I created this file.

Source shows `unsigned long`, so `u32`

https://elixir.bootlin.com/linux/latest/source/ipc/shm.c#L57
https://elixir.bootlin.com/linux/latest/source/ipc/shm.c#L1867

However, when creating a shared memory segment, it can be much bigger. In the create function, it is defined as a `size_t`, so `u64`

After testing, I can create a memory segment of 6 GB, the size field show `6425673728`