### PR TITLE
Document new MSRV policy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ["1.48.0", "stable", "beta", "nightly"]
+        toolchain: ["stable", "beta", "nightly"]
     runs-on: ubuntu-latest
 
     steps:
@@ -26,24 +26,6 @@ jobs:
     
     - name: Build
       run: cargo +${{ matrix.toolchain }} build --verbose
-    - name: Pin plotters
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p plotters --precise 0.3.1
-    - name: Pin once_cell
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p once_cell --precise 1.14.0
-    - name: Pin rayon
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p rayon --precise 1.5.3
-    - name: Pin rayon-core
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p rayon-core --precise 1.9.3
-    - name: Pin backtrace
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p backtrace --precise 0.3.66
-    - name: Pin object
-      if: matrix.toolchain == '1.48.0'
-      run: cargo update -p object --precise 0.29.0
     - name: Run tests
       run: cargo +${{ matrix.toolchain }} test --all-features --verbose -- --skip _runsinglethread
     - name: Run tests (single-threaded tests)
@@ -60,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ["1.48.0", "stable", "beta", "nightly"]
+        toolchain: ["stable", "beta", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,15 +58,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: i686-unknown-linux-gnu
 
-      - name: Pin once_cell
-        if: matrix.toolchain == '1.48.0'
-        run: cargo update -p once_cell --precise 1.14.0
-      - name: Pin backtrace
-        if: matrix.toolchain == '1.48.0'
-        run: cargo update -p backtrace --precise 0.3.66
-      - name: Pin object
-        if: matrix.toolchain == '1.48.0'
-        run: cargo update -p object --precise 0.29.0
       - name: cargo check (aarch64)
         run: cargo +${{ matrix.toolchain }} check --target aarch64-linux-android --all-features
       - name: cargo check (i686)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ specified here, since serde does not not have an MSRV policy.
 
 ## Minimum Rust Version
 
-This crate requires a minimum rust version of 1.48.0 (2020-11-19).
+This crate is only tested against the latest stable rustc compiler, but may
+work with older compilers.  See [msrv.md](msrv.md) for more details.
 
 ## License
 

--- a/msrv.md
+++ b/msrv.md
@@ -1,0 +1,28 @@
+# MSRV for the `procfs` crate
+
+The latest version of the `procfs` crate is only tested against the latest stable compiler.  However, it
+may work with older compilers.
+
+If you are using an older compiler and need a `procfs` bug fix on an older `procfs` version,
+please open an issue on github, and we'll backport that bugfix.  If you need a
+feature backported, please also open an issue to ask for a backport, but you may
+be asked to help by opening a PR.
+
+If you have any comments on this MSRV policy, please leave a comment
+[on this issue](https://github.com/eminence/procfs/issues/223).
+
+The table below attempts to list the latest version of `procfs` you can use, for
+a given rustc compiler.
+
+
+| Rust Version 	| `procfs` version 	| Notes 	|
+|---	| --- 	|--- 	|
+| Latest 	| Latest	| The latest version of procfs always supports the latest rustc compiler 	|
+| 1.48 to 1.67 | 0.15 | [^1] |
+| 1.34 to 1.54 | 0.13 | [^1] [^2] |
+
+
+[^1]: `procfs` will support these older versions of rustc, but you'll need
+to pin some of the `procfs` dependencies to older versions.  The dependencies that need pinning can change over time, but are likely `hex`, `bitflags`, and `flate2`.
+
+[^2]: If you use the optional backtrace feature, you'll need rust 1.42 or newer.


### PR DESCRIPTION
The upcoming procfs version 0.15 will work with rust 1.48, but the README will say that only the latest stable compiler is tested