### PR TITLE
Don't error if the oppportunistic statat fails in fd_count

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1183,7 +1183,7 @@ impl Process {
         // Use fast path if available (Linux v6.2): https://github.com/torvalds/linux/commit/f1f1f2569901
         let stat = wrap_io_error!(
             self.root.join("fd"),
-            rustix::fs::statat(&self.fd, "fd", AtFlags::SYMLINK_NOFOLLOW)
+            rustix::fs::statat(&self.fd, "fd", AtFlags::empty())
         )?;
         if stat.st_size > 0 {
             return Ok(stat.st_size as usize);


### PR DESCRIPTION
It was reported (#241) that old kernels (2.6) will return a failure if SYMLINK_NOFOLLOW is used, so lets check for errors here.