### PR TITLE
Convert PID and TID to u32

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,7 +1,7 @@
 extern crate procfs;
 
 fn main() {
-    let pid = std::env::args().nth(1).and_then(|s| s.parse::<i32>().ok());
+    let pid = std::env::args().nth(1).and_then(|s| s.parse::<u32>().ok());
 
     let prc = if let Some(pid) = pid {
         println!("Info for pid={}", pid);

--- a/examples/lslocks.rs
+++ b/examples/lslocks.rs
@@ -21,7 +21,8 @@ fn main() {
                 },
             );
 
-        print!("{:<12} ", lock.pid.unwrap_or(-1));
+        let display_pid = lock.pid.map(|x| x.to_string()).unwrap_or((-1).to_string());
+        print!("{:<12} ", display_pid);
         print!("{:12} ", lock.lock_type.as_str());
         print!("{:12} ", lock.mode.as_str());
         print!("{:12} ", lock.kind.as_str());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1420,7 +1420,7 @@ mod tests {
             .arg("10000")
             .spawn()
             .expect("Failed to start sleep");
-        let p = crate::process::Process::new(command.id() as i32).expect("Failed to create Process");
+        let p = crate::process::Process::new(command.id()).expect("Failed to create Process");
         command.kill().expect("Failed to kill sleep");
         command.wait().expect("Failed to wait for sleep");
         let e = p.stat().unwrap_err();

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -130,7 +130,7 @@ pub struct Lock {
     ///
     /// Before kernel 4.14 a bug meant that the PID of of the process that initially
     /// acquired the lock was displayed instead of `None`.
-    pub pid: Option<i32>,
+    pub pid: Option<u32>,
     /// The major ID of the device containing the FS that contains this lock
     pub devmaj: u32,
     /// The minor ID of the device containing the FS that contains this lock
@@ -178,7 +178,7 @@ impl Lock {
             lock_type: typ,
             mode,
             kind,
-            pid: if pid == "-1" { None } else { Some(from_str!(i32, pid)) },
+            pid: if pid == "-1" { None } else { Some(from_str!(u32, pid)) },
             devmaj,
             devmin,
             inode,

--- a/src/process/task.rs
+++ b/src/process/task.rs
@@ -13,9 +13,9 @@ use rustix::fd::{BorrowedFd, OwnedFd};
 pub struct Task {
     fd: OwnedFd,
     /// The ID of the process that this task belongs to
-    pub pid: i32,
+    pub pid: u32,
     /// The task ID
-    pub tid: i32,
+    pub tid: u32,
     /// Task root: `/proc/<pid>/task/<tid>`
     pub(crate) root: PathBuf,
 }
@@ -28,8 +28,8 @@ impl Task {
         base: P,
         dirfd: BorrowedFd,
         path: Q,
-        pid: i32,
-        tid: i32,
+        pid: u32,
+        tid: u32,
     ) -> ProcResult<Task> {
         use rustix::fs::{Mode, OFlags};
 
@@ -231,7 +231,7 @@ mod tests {
 
         let children = crate::process::Process::myself()
             .unwrap()
-            .task_from_tid(tid.as_raw_nonzero().get() as i32)
+            .task_from_tid(tid.as_raw_nonzero().get())
             .unwrap()
             .children()
             .unwrap();


### PR DESCRIPTION
See issue #245

I tried to convert all the i32 fields to u32 for Process and Task.
I only had to mess a bit with the display code for the example lslocks.

Cargo check and test are OK, and I tested all the examples, everything works as expected

Feel free to discard this PR if you prefer to keep the current i32.