### PR TITLE
Implement some standard traits

### DIFF
--- a/procfs-core/src/process/pagemap.rs
+++ b/procfs-core/src/process/pagemap.rs
@@ -98,7 +98,7 @@ impl fmt::LowerHex for Pfn {
 }
 
 /// Represents a page table entry in `/proc/<pid>/pagemap`.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PageInfo {
     /// Entry referring to a memory page
     MemoryPage(MemoryPageFlags),

--- a/procfs-core/src/sysvipc_shm.rs
+++ b/procfs-core/src/sysvipc_shm.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// A shared memory segment parsed from `/proc/sysvipc/shm`
 /// Relation with [crate::process::MMapPath::Vsys]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[allow(non_snake_case)]
 pub struct Shm {


### PR DESCRIPTION
I implemented a few standard traits, but there's probably others.

For `Shm`, some field like `rss` or `atime` are not really part of the indentity of `Shm`, so I left them out