### PR TITLE
Bitflags v2

### DIFF
--- a/procfs-core/Cargo.toml
+++ b/procfs-core/Cargo.toml
@@ -14,11 +14,11 @@ rust-version.workspace = true
 
 [features]
 default = ["chrono"]
-serde1 = ["serde"]
+serde1 = ["serde", "bitflags/serde"]
 
 [dependencies]
 backtrace = { version = "0.3", optional = true }
-bitflags = "1.2"
+bitflags = { version = "2" }
 chrono = { version = "0.4.20", optional = true, features = ["clock"], default-features = false }
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/procfs-core/src/keyring.rs
+++ b/procfs-core/src/keyring.rs
@@ -10,6 +10,7 @@ use std::{collections::HashMap, io::BufRead, time::Duration};
 bitflags! {
     /// Various key flags
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct KeyFlags: u32 {
             /// The key has been instantiated
             const INSTANTIATED = 0x01;
@@ -33,6 +34,7 @@ bitflags! {
 bitflags! {
     /// Bitflags that represent the permissions for a key
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct PermissionFlags: u32 {
         /// The attributes of the key may be read
         ///
@@ -56,7 +58,7 @@ bitflags! {
         /// The ownership details and security label of the key may be changed, the key's expiration
         /// time may be set, and the key may be revoked.
         const SETATTR = 0x20;
-        const ALL = Self::VIEW.bits | Self::READ.bits | Self::WRITE.bits | Self::SEARCH.bits | Self::LINK.bits | Self::SETATTR.bits;
+        const ALL = Self::VIEW.bits() | Self::READ.bits() | Self::WRITE.bits() | Self::SEARCH.bits() | Self::LINK.bits() | Self::SETATTR.bits();
     }
 }
 

--- a/procfs-core/src/net.rs
+++ b/procfs-core/src/net.rs
@@ -368,6 +368,7 @@ bitflags! {
     /// Hardware type for an ARP table entry.
     // source: include/uapi/linux/if_arp.h
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct ARPHardware: u32 {
         /// NET/ROM pseudo
         const NETROM = 0;
@@ -406,6 +407,7 @@ bitflags! {
     /// Flags for ARP entries
     // source: include/uapi/linux/if_arp.h
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct ARPFlags: u32 {
             /// Completed entry
             const COM = 0x02;

--- a/procfs-core/src/process/mod.rs
+++ b/procfs-core/src/process/mod.rs
@@ -44,6 +44,7 @@ bitflags! {
     ///
     /// See also the [Stat::flags()] method.
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct StatFlags: u32 {
         /// I am an IDLE thread
         const PF_IDLE = 0x0000_0002;
@@ -114,6 +115,7 @@ bitflags! {
 bitflags! {
     /// See the [coredump_filter()](struct.Process.html#method.coredump_filter) method.
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct CoredumpFlags: u32 {
         const ANONYMOUS_PRIVATE_MAPPINGS = 0x01;
         const ANONYMOUS_SHARED_MAPPINGS = 0x02;
@@ -133,8 +135,8 @@ bitflags! {
     /// Note that the `SHARED` and `PRIVATE` are mutually exclusive, so while you can
     /// use `MMPermissions::all()` to construct an instance that has all bits set,
     /// this particular value would never been seen in procfs.
-    #[derive(Default)]
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Default)]
     pub struct MMPermissions: u8 {
         /// No permissions
         const NONE = 0;
@@ -202,8 +204,8 @@ impl FromStr for MMPermissions {
 bitflags! {
     /// Represents the kernel flags associated with the virtual memory area.
     /// The names of these flags are just those you'll find in the man page, but in upper case.
-    #[derive(Default)]
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Default)]
     pub struct VmFlags: u32 {
         /// No flags
         const NONE = 0;

--- a/procfs-core/src/process/mount.rs
+++ b/procfs-core/src/process/mount.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 bitflags! {
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct NFSServerCaps: u32 {
 
         const NFS_CAP_READDIRPLUS = 1;

--- a/procfs-core/src/process/pagemap.rs
+++ b/procfs-core/src/process/pagemap.rs
@@ -16,6 +16,7 @@ const MAX_SWAPFILES_SHIFT: usize = 5;
 bitflags! {
     /// Represents the fields and flags in a page table entry for a swapped page.
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct SwapPageFlags: u64 {
         /// Swap type if swapped
         #[doc(hidden)]
@@ -52,6 +53,7 @@ impl SwapPageFlags {
 bitflags! {
     /// Represents the fields and flags in a page table entry for a memory page.
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct MemoryPageFlags: u64 {
         /// Page frame number if present
         #[doc(hidden)]
@@ -108,10 +110,10 @@ pub enum PageInfo {
 
 impl PageInfo {
     pub fn parse_info(info: u64) -> Self {
-        let flags = MemoryPageFlags::from_bits_truncate(info);
+        let flags = MemoryPageFlags::from_bits_retain(info);
 
         if flags.contains(MemoryPageFlags::SWAP) {
-            Self::SwapPage(SwapPageFlags::from_bits_truncate(info))
+            Self::SwapPage(SwapPageFlags::from_bits_retain(info))
         } else {
             Self::MemoryPage(flags)
         }

--- a/procfs-core/src/sys/kernel/mod.rs
+++ b/procfs-core/src/sys/kernel/mod.rs
@@ -273,6 +273,7 @@ impl FromStr for SemaphoreLimits {
 
 bitflags! {
     /// Flags representing allowed sysrq functions
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct AllowedFunctions : u16 {
         /// Enable control of console log level
         const ENABLE_CONTROL_LOG_LEVEL = 2;
@@ -309,7 +310,7 @@ impl SysRq {
         match self {
             SysRq::Disable => 0,
             SysRq::Enable => 1,
-            SysRq::AllowedFunctions(allowed) => allowed.bits,
+            SysRq::AllowedFunctions(allowed) => allowed.bits(),
         }
     }
 

--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -19,7 +19,7 @@ serde1 = ["serde", "procfs-core/serde1"]
 [dependencies]
 procfs-core = { path = "../procfs-core" }
 rustix = { version = "0.37.0", features = ["fs", "process", "param", "thread"] }
-bitflags = "1.2"
+bitflags = { version = "2.0", default-features = false }
 lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }
 hex = "0.4"

--- a/procfs/src/kpageflags.rs
+++ b/procfs/src/kpageflags.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 bitflags! {
     /// Represents the fields and flags in a page table entry for a memory page.
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct PhysicalPageFlags: u64 {
         /// The page is being locked for exclusive access, e.g. by undergoing read/write IO
         const LOCKED = 1 << 0;

--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -93,6 +93,7 @@ bitflags! {
     ///
     /// [documented]: https://man7.org/linux/man-pages/man2/chmod.2.html#DESCRIPTION
     #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct FDPermissions: u16 {
         const READ = Mode::RUSR.bits() as u16;
         const WRITE = Mode::WUSR.bits() as u16;
@@ -217,7 +218,7 @@ impl Process {
         // for 2.6.39 <= kernel < 3.6 fstat doesn't support O_PATH see https://github.com/eminence/procfs/issues/265
         let flags = match *crate::KERNEL {
             Ok(v) if v < KernelVersion::new(3, 6, 0) => OFlags::DIRECTORY | OFlags::CLOEXEC,
-            Ok(v) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Ok(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
             Err(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
         };
         let file = wrap_io_error!(root, rustix::fs::openat(rustix::fs::cwd(), &root, flags, Mode::empty()))?;

--- a/procfs/src/sys/fs/binfmt_misc.rs
+++ b/procfs/src/sys/fs/binfmt_misc.rs
@@ -105,6 +105,7 @@ impl BinFmtEntry {
 
 bitflags! {
     /// Various key flags
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct BinFmtFlags: u8 {
             /// Preserve Argv[0]
             ///

--- a/procfs/src/sys/kernel/mod.rs
+++ b/procfs/src/sys/kernel/mod.rs
@@ -355,6 +355,7 @@ pub fn shmmni() -> ProcResult<u64> {
 
 bitflags! {
     /// Flags representing allowed sysrq functions
+    #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
     pub struct AllowedFunctions : u16 {
         /// Enable control of console log level
         const ENABLE_CONTROL_LOG_LEVEL = 2;
@@ -393,7 +394,7 @@ impl SysRq {
         match self {
             SysRq::Disable => 0,
             SysRq::Enable => 1,
-            SysRq::AllowedFunctions(allowed) => allowed.bits,
+            SysRq::AllowedFunctions(allowed) => allowed.bits(),
         }
     }
 


### PR DESCRIPTION
Update to bitflags v2, it's a big update

Changelog is not clean yet, so migration path is not complete
See https://github.com/bitflags/bitflags/issues/310

At the moment, I only updated the version, and implemented derived Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord
From the mentioned PR, seems like we'll need to add some repr(transparent) if we want serde to work.

Maybe it's better to wait until the complete migration guide is finished