### PR TITLE
Don't hide process creation errors in all_processes

### DIFF
--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -957,9 +957,7 @@ impl std::iter::Iterator for ProcessesIter {
             match self.inner.next() {
                 Some(Ok(entry)) => {
                     if let Ok(pid) = i32::from_str(&entry.file_name().to_string_lossy()) {
-                        if let Ok(proc) = Process::new_with_root(self.root.join(pid.to_string())) {
-                            break Some(Ok(proc));
-                        }
+                        break Some(Process::new_with_root(self.root.join(pid.to_string())));
                     }
                 }
                 Some(Err(e)) => break Some(Err(io::Error::from(e).into())),


### PR DESCRIPTION
This is followup of #188 

Current implementation hide `Process` creation errors in `all_processes`, making this function nearly useless in a resource constrained environment. Errors are silently ignored, making look like only a few processes exist.

The fact that FDs are created for each process is not necessarily an issue, but users of the library must have a way to know if any operation worked as expected or not.

This PR shouldn't change much for users, because the `Processes` are wrapped in a `Result` either way


Example usage

```rust

let all_processes: Vec<Process> = procfs::process::all_processes()
    .unwrap()
    .filter_map(|p| match p {
        Ok(p) => Some(p),                              // happy path
        Err(e) => match e {
            procfs::ProcError::NotFound(_) => None,    // process vanished during iteration
            procfs::ProcError::Io(e, path) => None,    // can match on path to decide if we can continue
            x => {
                panic!("Can't read process {x:?}");    // some unknown error
            }
        },
    })
    .collect();
```