### PR TITLE
Update to rustix 0.37.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["chrono", "flate2"]
 serde1 = ["serde"]
 
 [dependencies]
-rustix = { version = "0.36.0", features = ["fs", "process", "param", "thread"] }
+rustix = { version = "0.37.0", features = ["fs", "process", "param", "thread"] }
 bitflags = "1.2"
 lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }


### PR DESCRIPTION
procfs doesn't need any code changes to update to rustix 0.37.