### PR TITLE
Fix handling of false default-features.

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -13,11 +13,11 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["chrono", "flate2"]
+default = ["chrono", "flate2", "procfs-core/default"]
 serde1 = ["serde", "procfs-core/serde1"]
 
 [dependencies]
-procfs-core = { path = "../procfs-core", version = "0.16.0-RC1" }
+procfs-core = { path = "../procfs-core", version = "0.16.0-RC1", default-features = false }
 rustix = { version = "0.37.0", features = ["fs", "process", "param", "thread"] }
 bitflags = { version = "2.0", default-features = false }
 lazy_static = "1.0.2"


### PR DESCRIPTION
Without this it is impossible to turn off procfs-core's default-features.