### PR TITLE
Dependency upgrades (rustix, criterion)

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -18,7 +18,7 @@ serde1 = ["serde", "procfs-core/serde1"]
 
 [dependencies]
 procfs-core = { path = "../procfs-core", version = "0.16.0-RC1", default-features = false }
-rustix = { version = "0.37.0", features = ["fs", "process", "param", "thread"] }
+rustix = { version = "0.38.4", features = ["fs", "process", "param", "system", "thread"] }
 bitflags = { version = "2.0", default-features = false }
 lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }
@@ -28,7 +28,7 @@ backtrace = { version = "0.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 procinfo = "0.4.2"
 failure = "0.1"
 libc = "0.2.139"

--- a/procfs/src/lib.rs
+++ b/procfs/src/lib.rs
@@ -372,7 +372,7 @@ impl Current for KernelConfig {
                 unreachable!("flate2 feature not enabled")
             }
         } else {
-            let kernel = rustix::process::uname();
+            let kernel = rustix::system::uname();
 
             let filename = format!("{}-{}", BOOT_CONFIG, kernel.release().to_string_lossy());
 

--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -221,7 +221,7 @@ impl Process {
             Ok(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
             Err(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
         };
-        let file = wrap_io_error!(root, rustix::fs::openat(rustix::fs::cwd(), &root, flags, Mode::empty()))?;
+        let file = wrap_io_error!(root, rustix::fs::openat(rustix::fs::CWD, &root, flags, Mode::empty()))?;
 
         let pidres = root
             .as_path()
@@ -233,7 +233,7 @@ impl Process {
             })
             .and_then(|s| s.to_string_lossy().parse::<i32>().ok())
             .or_else(|| {
-                rustix::fs::readlinkat(rustix::fs::cwd(), &root, Vec::new())
+                rustix::fs::readlinkat(rustix::fs::CWD, &root, Vec::new())
                     .ok()
                     .and_then(|s| s.to_string_lossy().parse::<i32>().ok())
             });
@@ -947,7 +947,7 @@ pub fn all_processes_with_root(root: impl AsRef<Path>) -> ProcResult<ProcessesIt
     let dir = wrap_io_error!(
         root,
         rustix::fs::openat(
-            rustix::fs::cwd(),
+            rustix::fs::CWD,
             root,
             OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
             Mode::empty()


### PR DESCRIPTION
Upgrades the following crates:
- `rustix`: 0.37.0 ➡️ 0.38.4
- `criterion`: 0.3 ➡️ 0.5