### PR TITLE
Bump rustix dependency to 0.38.19

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -18,7 +18,7 @@ serde1 = ["serde", "procfs-core/serde1"]
 
 [dependencies]
 procfs-core = { path = "../procfs-core", version = "0.16.0-RC1", default-features = false }
-rustix = { version = "0.38.4", features = ["fs", "process", "param", "system", "thread"] }
+rustix = { version = "0.38.19", features = ["fs", "process", "param", "system", "thread"] }
 bitflags = { version = "2.0", default-features = false }
 lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }


### PR DESCRIPTION
This resolves GHSA-c827-hfw6-qwvm