### PR TITLE
cgroups: skip empty controllers

### DIFF
--- a/procfs-core/src/cgroups.rs
+++ b/procfs-core/src/cgroups.rs
@@ -99,6 +99,7 @@ impl crate::FromBufRead for ProcessCGroups {
             let hierarchy = from_str!(u32, expect!(s.next(), "hierarchy"));
             let controllers = expect!(s.next(), "controllers")
                 .split(',')
+                .filter(|s| !s.is_empty())
                 .map(|s| s.to_owned())
                 .collect();
             let pathname = expect!(s.next(), "path").to_owned();


### PR DESCRIPTION
In case of cgroupv2, the controllers list is empty.

Splitting it by comma results in a vector with a single empty element ([""]), instead of an empty vector ([]).