### PR TITLE
Ship copyright and license files with split crates

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,6 +1,6 @@
 The source code for the procfs library is copyright by Andrew Chin, 2019, and other contributors.
 
-It is icensed under either of
+It is licensed under either of
 
  * Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0
  * MIT license, http://opensource.org/licenses/MIT

--- a/procfs-core/COPYRIGHT.txt
+++ b/procfs-core/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+../COPYRIGHT.txt

--- a/procfs-core/LICENSE-APACHE
+++ b/procfs-core/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/procfs-core/LICENSE-MIT
+++ b/procfs-core/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/procfs/COPYRIGHT.txt
+++ b/procfs/COPYRIGHT.txt
@@ -1,0 +1,1 @@
+../COPYRIGHT.txt

--- a/procfs/LICENSE-APACHE
+++ b/procfs/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/procfs/LICENSE-MIT
+++ b/procfs/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Now that `procfs` and `procfs-core` are individual crates located in subdirectories of the repo, make sure the copyright and license texts are symlinked so they get packaged when the crates are published.

Also fix typoo in COPYRIGHT.txt

```
michel in procfs/procfs-core on  add-license [!?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
   Packaging procfs-core v0.16.0 (/home/michel/src/github/eminence/procfs/procfs-core)
    Packaged 32 files, 329.5KiB (78.3KiB compressed)

michel in procfs/procfs-core on  add-license [!?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ bsdtar tf ../target/package/procfs-core-0.16.0.crate | grep COPYRIGHT
procfs-core-0.16.0/COPYRIGHT.txt

michel in procfs/procfs-core on  add-license [!?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ bsdtar tf ../target/package/procfs-core-0.16.0.crate | grep LICENSE
procfs-core-0.16.0/LICENSE-APACHE
procfs-core-0.16.0/LICENSE-MIT
```

```
michel in procfs/procfs on  add-license [?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
   Packaging procfs v0.16.0 (/home/michel/src/github/eminence/procfs/procfs)
    Updating crates.io index
    Packaged 48 files, 266.1KiB (71.7KiB compressed)

michel in procfs/procfs on  add-license [?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0 took 2s
⬢ [fedora-toolbox:38] ❯ bsdtar tf ../target/package/procfs-0.16.0.crate | grep COPYRIGHT
procfs-0.16.0/COPYRIGHT.txt

michel in procfs/procfs on  add-license [?] via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ bsdtar tf ../target/package/procfs-0.16.0.crate | grep LICENSE
procfs-0.16.0/LICENSE-APACHE
procfs-0.16.0/LICENSE-MIT
```