### PR TITLE
Add oom_score_adj Process methods

### DIFF
--- a/procfs-core/src/partitions.rs
+++ b/procfs-core/src/partitions.rs
@@ -18,7 +18,7 @@ pub struct PartitionEntry {
     /// Number of 1024 byte blocks
     pub blocks: u64,
     /// Device name
-    pub name: String
+    pub name: String,
 }
 
 impl super::FromBufRead for Vec<PartitionEntry> {
@@ -37,9 +37,9 @@ impl super::FromBufRead for Vec<PartitionEntry> {
 
             let partition_entry = PartitionEntry {
                 major,
-		minor,
-		blocks,
-		name
+                minor,
+                blocks,
+                name,
             };
 
             vec.push(partition_entry);
@@ -48,7 +48,6 @@ impl super::FromBufRead for Vec<PartitionEntry> {
         Ok(vec)
     }
 }
-
 
 #[test]
 fn test_partitions() {

--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -587,12 +587,29 @@ impl Process {
     /// A higher score means that the process is more likely to be selected by the OOM-killer.
     /// The basis for this score is the amount of memory used by the process, plus other factors.
     ///
+    /// Values range from 0 (never kill) to 1000 (always kill) inclusive.
+    ///
     /// (Since linux 2.6.11)
-    pub fn oom_score(&self) -> ProcResult<u32> {
+    pub fn oom_score(&self) -> ProcResult<u16> {
         let mut file = FileWrapper::open_at(&self.root, &self.fd, "oom_score")?;
         let mut oom = String::new();
         file.read_to_string(&mut oom)?;
-        Ok(from_str!(u32, oom.trim()))
+        Ok(from_str!(u16, oom.trim()))
+    }
+
+    /// Adjust score value is added to the oom score before choosing processes to kill.
+    ///
+    /// Values range from -1000 (never kill) to 1000 (always kill) inclusive.
+    pub fn oom_score_adj(&self) -> ProcResult<i16> {
+        let mut file = FileWrapper::open_at(&self.root, &self.fd, "oom_score_adj")?;
+        let mut oom = String::new();
+        file.read_to_string(&mut oom)?;
+        Ok(from_str!(i16, oom.trim()))
+    }
+
+    pub fn set_oom_score_adj(&self, new_oom_score_adj: i16) -> ProcResult<()> {
+        let path = self.root.join("oom_score_adj");
+        write_value(path, new_oom_score_adj)
     }
 
     /// Set process memory information

--- a/procfs/src/process/tests.rs
+++ b/procfs/src/process/tests.rs
@@ -174,6 +174,10 @@ fn test_all() {
         check_unwrap(&prc, prc.mountinfo());
         check_unwrap(&prc, prc.mountstats());
         check_unwrap(&prc, prc.oom_score());
+        if let Some(oom_score_adj) = check_unwrap(&prc, prc.oom_score_adj()) {
+            assert!(oom_score_adj >= -1000 && oom_score_adj <= 1000);
+            check_unwrap(&prc, prc.set_oom_score_adj(oom_score_adj));
+        }
 
         if let Some(tasks) = check_unwrap(&prc, prc.tasks()) {
             for task in tasks {

--- a/support.md
+++ b/support.md
@@ -36,7 +36,7 @@ This is an approximate list of all the files under the `/proc` mount, and an ind
   * [ ] `/proc/[pid]/numa_maps`
   * [ ] `/proc/[pid]/oom_adj`
   * [x] `/proc/[pid]/oom_score`
-  * [ ] `/proc/[pid]/oom_score_adj`
+  * [x] `/proc/[pid]/oom_score_adj`
   * [ ] `/proc/[pid]/pagemap`
   * [ ] `/proc/[pid]/personality`
   * [x] `/proc/[pid]/root`


### PR DESCRIPTION
I took note of this comment: https://github.com/eminence/procfs/pull/139#pullrequestreview-737802630:

> So the way I read this is: while the final OOM "score" will be somewhere between 0 and 1000, the value reported in oom_score_adj can be between -1000 and 1000. So I think the oom_score_adj function should return a i16 not u32.

And changed `oom_score` type to u16 too, since it too only ranges from 0 to 1000.

Previous attempt: https://github.com/eminence/procfs/pull/139