### PR TITLE
Remove lazy-static dependency

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -20,7 +20,6 @@ serde1 = ["serde", "procfs-core/serde1"]
 procfs-core = { path = "../procfs-core", version = "0.16.0-RC1", default-features = false }
 rustix = { version = "0.38.19", features = ["fs", "process", "param", "system", "thread"] }
 bitflags = { version = "2.0", default-features = false }
-lazy_static = "1.0.2"
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }
 hex = "0.4"
 flate2 = { version = "1.0.3", optional = true }

--- a/procfs/src/lib.rs
+++ b/procfs/src/lib.rs
@@ -49,7 +49,6 @@
 pub use procfs_core::*;
 
 use bitflags::bitflags;
-use lazy_static::lazy_static;
 
 use rustix::fd::AsFd;
 use std::collections::HashMap;
@@ -201,28 +200,6 @@ pub mod sys;
 pub use crate::sys::kernel::BuildInfo as KernelBuildInfo;
 pub use crate::sys::kernel::Type as KernelType;
 pub use crate::sys::kernel::Version as KernelVersion;
-
-lazy_static! {
-    /// The number of clock ticks per second.
-    ///
-    /// This is calculated from `sysconf(_SC_CLK_TCK)`.
-    static ref TICKS_PER_SECOND: u64 = {
-        ticks_per_second()
-    };
-    /// The version of the currently running kernel.
-    ///
-    /// This is a lazily constructed static.  You can also get this information via
-    /// [KernelVersion::new()].
-    static ref KERNEL: ProcResult<KernelVersion> = {
-        KernelVersion::current()
-    };
-    /// Memory page size, in bytes.
-    ///
-    /// This is calculated from `sysconf(_SC_PAGESIZE)`.
-    static ref PAGESIZE: u64 = {
-        page_size()
-    };
-}
 
 /// A wrapper around a `File` that remembers the name of the path
 struct FileWrapper {
@@ -524,9 +501,7 @@ mod tests {
 
     #[test]
     fn test_statics() {
-        println!("{:?}", *TICKS_PER_SECOND);
-        println!("{:?}", *KERNEL);
-        println!("{:?}", *PAGESIZE);
+        println!("{:?}", crate::sys::kernel::Version::cached());
     }
 
     #[test]

--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -66,6 +66,7 @@
 
 use super::*;
 use crate::net::{TcpNetEntry, UdpNetEntry};
+use crate::sys::kernel::Version;
 
 pub use procfs_core::process::*;
 use rustix::fd::{AsFd, BorrowedFd, OwnedFd, RawFd};
@@ -154,7 +155,7 @@ impl FDInfo {
         let p = path.as_ref();
         let root = base.as_ref().join(p);
         // for 2.6.39 <= kernel < 3.6 fstat doesn't support O_PATH see https://github.com/eminence/procfs/issues/265
-        let flags = match *crate::KERNEL {
+        let flags = match Version::cached() {
             Ok(v) if v < KernelVersion::new(3, 6, 0) => OFlags::NOFOLLOW | OFlags::CLOEXEC,
             Ok(_) => OFlags::NOFOLLOW | OFlags::PATH | OFlags::CLOEXEC,
             Err(_) => OFlags::NOFOLLOW | OFlags::PATH | OFlags::CLOEXEC,
@@ -224,7 +225,7 @@ impl Process {
     /// Returns a `Process` based on a specified `/proc/<pid>` path.
     pub fn new_with_root(root: PathBuf) -> ProcResult<Process> {
         // for 2.6.39 <= kernel < 3.6 fstat doesn't support O_PATH see https://github.com/eminence/procfs/issues/265
-        let flags = match *crate::KERNEL {
+        let flags = match Version::cached() {
             Ok(v) if v < KernelVersion::new(3, 6, 0) => OFlags::DIRECTORY | OFlags::CLOEXEC,
             Ok(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
             Err(_) => OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,

--- a/procfs/src/sys/kernel/random.rs
+++ b/procfs/src/sys/kernel/random.rs
@@ -3,16 +3,14 @@
 //! Note that some of these entries are only documented in random(4), while some are also documented under proc(5)
 
 use crate::{read_value, write_value, ProcError, ProcResult};
-use lazy_static::lazy_static;
+use std::path::Path;
 
-lazy_static! {
-    static ref RANDOM_ROOT: std::path::PathBuf = std::path::PathBuf::from("/proc/sys/kernel/random");
-}
+const RANDOM_ROOT: &str = "/proc/sys/kernel/random"; 
 
 /// This read-only file gives the available entropy, in bits. This will be a number in the range
 /// 0 to 4096
 pub fn entropy_avail() -> ProcResult<u16> {
-    read_value(RANDOM_ROOT.join("entropy_avail"))
+    read_value(Path::new(RANDOM_ROOT).join("entropy_avail"))
 }
 
 /// This file gives the size of the entropy pool
@@ -22,7 +20,7 @@ pub fn entropy_avail() -> ProcResult<u16> {
 ///
 /// See `man random(4)` for more information
 pub fn poolsize() -> ProcResult<u16> {
-    read_value(RANDOM_ROOT.join("poolsize"))
+    read_value(Path::new(RANDOM_ROOT).join("poolsize"))
 }
 
 /// This file contains the number of bits of entropy required for waking up processes that sleep waiting
@@ -33,10 +31,10 @@ pub fn poolsize() -> ProcResult<u16> {
 /// This will first attempt to read from `/proc/sys/kernel/random/read_wakeup_threshold` but it
 /// will fallback to `/proc/sys/kernel/random/write_wakeup_threshold` if the former file is not found.
 pub fn read_wakeup_threshold() -> ProcResult<u32> {
-    match read_value(RANDOM_ROOT.join("read_wakeup_threshold")) {
+    match read_value(Path::new(RANDOM_ROOT).join("read_wakeup_threshold")) {
         Ok(val) => Ok(val),
         Err(err) => match err {
-            ProcError::NotFound(_) => read_value(RANDOM_ROOT.join("write_wakeup_threshold")),
+            ProcError::NotFound(_) => read_value(Path::new(RANDOM_ROOT).join("write_wakeup_threshold")),
             err => Err(err),
         },
     }
@@ -45,17 +43,17 @@ pub fn read_wakeup_threshold() -> ProcResult<u32> {
 /// This file contains the number of bits of entropy below which we wake up processes that do a
 /// select(2) or poll(2) for write access to /dev/random. These values can be changed by writing to the file.
 pub fn write_wakeup_threshold(new_value: u32) -> ProcResult<()> {
-    write_value(RANDOM_ROOT.join("write_wakeup_threshold"), new_value)
+    write_value(Path::new(RANDOM_ROOT).join("write_wakeup_threshold"), new_value)
 }
 
 /// This read-only file randomly generates a fresh 128-bit UUID on each read
 pub fn uuid() -> ProcResult<String> {
-    read_value(RANDOM_ROOT.join("uuid"))
+    read_value(Path::new(RANDOM_ROOT).join("uuid"))
 }
 
 /// This is a read-only file containing a 128-bit UUID generated at boot
 pub fn boot_id() -> ProcResult<String> {
-    read_value(RANDOM_ROOT.join("boot_id"))
+    read_value(Path::new(RANDOM_ROOT).join("boot_id"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
lazy-static is on its way to being deprecated. I'm trying to remove it
from my dependency tree. Therefore I've removed lazy-static from this
crate in this commit.

Modifications made:

- PAGESIZE and TICKS_PER_SECOND appear to be unused so I've removed
  them.
- KERNEL can be replaced with racy atomic initialization.
- RANDOM_ROOT doesn't really need to be allocated on the heap, so I've
  replaced it with manual Path::new.
