### PR TITLE
Fix build error with backtrace feature enabled

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -13,6 +13,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+backtrace = ["dep:backtrace", "procfs-core/backtrace"]
 default = ["chrono", "flate2", "procfs-core/default"]
 serde1 = ["serde", "procfs-core/serde1"]
 


### PR DESCRIPTION
The `procfs/backtrace` feature needs the `procfs-core/backtrace` feature.