### PR TITLE
Enable `generate-link-to-definition` rustdoc feature on docs.rs

### DIFF
--- a/procfs-core/Cargo.toml
+++ b/procfs-core/Cargo.toml
@@ -25,3 +25,4 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]

--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -35,6 +35,7 @@ libc = "0.2.139"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [[bench]]
 name = "cpuinfo"


### PR DESCRIPTION
This feature is very useful when browsing source code directly on docs.rs (from the source link). Example with `syn` crate: https://docs.rs/syn/latest/src/syn/lib.rs.html#950