### PR TITLE
Work around 32/64 bit mismatch

### DIFF
--- a/procfs/src/process/tests.rs
+++ b/procfs/src/process/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use rustix::process::Resource;
+use std::convert::TryInto;
 
 fn check_unwrap<T>(prc: &Process, val: ProcResult<T>) -> Option<T> {
     match val {
@@ -458,7 +459,7 @@ fn test_proc_auxv() {
         if k != 16 {
             // for reasons i do not understand, getauxval(AT_HWCAP) doesn't return the expected
             // value
-            assert_eq!(v, unsafe { libc::getauxval(k) });
+            assert_eq!(v, unsafe { libc::getauxval(k.try_into().unwrap()).into() });
         }
     }
 }


### PR DESCRIPTION
Fixes #325.

Based on the Rust compiler’s suggestions:

```
error[E0308]: mismatched types
    --> procfs/src/process/tests.rs:461:52
     |
461  |             assert_eq!(v, unsafe { libc::getauxval(k) });
     |                                    --------------- ^ expected `u32`, found `u64`
     |                                    |
     |                                    arguments to this function are incorrect
     |
note: function defined here
    --> /builddir/.cargo/registry/src/index.crates.io-1cd66030c949c28d/libc-0.2.169/src/unix/linux_like/linux/gnu/mod.rs:1340:12
     |
1340 |     pub fn getauxval(type_: c_ulong) -> c_ulong;
     |            ^^^^^^^^^
help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
     |
461  |             assert_eq!(v, unsafe { libc::getauxval(k.try_into().unwrap()) });
     |                                                     ++++++++++++++++++++

error[E0308]: mismatched types   
   --> procfs/src/process/tests.rs:461:27
    |
461 |             assert_eq!(v, unsafe { libc::getauxval(k) });
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `u32`
    |
help: you can convert a `u32` to a `u64`
    |
461 |             assert_eq!(v, unsafe { libc::getauxval(k).into() });
    |                                                      +++++++
```