### PR TITLE
replace hardcoded crate name by env var that returns the crate's name dynamically

### DIFF
--- a/procfs/build.rs
+++ b/procfs/build.rs
@@ -2,7 +2,7 @@ fn main() {
     // Filters are extracted from `libc` filters
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("Missing CARGO_CFG_TARGET_OS envvar");
     if !["android", "linux", "l4re"].contains(&target_os.as_str()) {
-        eprintln!("Building procfs on an for a unsupported platform. Currently only linux and android are supported");
+        eprintln!("Building {} on an for a unsupported platform. Currently only linux and android are supported", env!("CARGO_PKG_NAME"));
         eprintln!("(Your current target_os is {})", target_os);
         std::process::exit(1)
     }


### PR DESCRIPTION
Disclaimer: That's a trivial patch and it doesn't add any new functionality. 