### PR TITLE
Fix lints as the names have changed

### DIFF
--- a/procfs-core/src/lib.rs
+++ b/procfs-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints)]
-#![deny(broken_intra_doc_links, invalid_html_tags)]
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::invalid_html_tags)]
 //! This crate provides to an interface into the linux `procfs` filesystem, usually mounted at
 //! `/proc`.
 //!


### PR DESCRIPTION
```
warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
 --> procfs-core/src/lib.rs:2:9
  |
2 | #![deny(broken_intra_doc_links, invalid_html_tags)]
  |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default

warning: lint `invalid_html_tags` has been renamed to `rustdoc::invalid_html_tags`
 --> procfs-core/src/lib.rs:2:33
  |
2 | #![deny(broken_intra_doc_links, invalid_html_tags)]
  |                                 ^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::invalid_html_tags`

warning: 2 warnings emitted
```

Test Plan
=========

ci