### PR TITLE
Check process name in test_proc_status_for_kthreadd

### DIFF
--- a/procfs/src/process/tests.rs
+++ b/procfs/src/process/tests.rs
@@ -710,6 +710,11 @@ fn test_proc_status_for_kthreadd() {
     let status = kthreadd.status().unwrap();
     println!("{:?}", status);
 
+    // actually check that pid2 is kthreadd
+    if status.name != "kthreadd" {
+        return; // ok we can still ignore
+    }
+
     assert_eq!(status.pid, 2);
     assert_eq!(status.vmpeak, None);
     assert_eq!(status.vmsize, None);


### PR DESCRIPTION
Hi again. While completing the update of procfs in Debian, Fabian Grünbichler discovered a bug in `test_proc_status_for_kthreadd`: some containers (or namespaces) may have a process with PID 2 which isn't kthreadd, which will make the test fail. This MR adds an explicit check for the process' name. I was given permission from Fabian to use his fix for this PR.

Cheers!