### PR TITLE
chore(deps): update `rustix` to 1.0.1

### DIFF
--- a/procfs/Cargo.toml
+++ b/procfs/Cargo.toml
@@ -19,7 +19,7 @@ serde1 = ["serde", "procfs-core/serde1"]
 
 [dependencies]
 procfs-core = { path = "../procfs-core", version = "0.17.0", default-features = false }
-rustix = { version = "0.38.19", features = ["fs", "process", "param", "system", "thread"] }
+rustix = { version = "1.0.1", features = ["fs", "process", "param", "system", "thread"] }
 bitflags = { version = "2.0", default-features = false }
 chrono = {version = "0.4.20", optional = true, features = ["clock"], default-features = false }
 flate2 = { version = "1.0.3", optional = true }


### PR DESCRIPTION
the `rustix` crate has released a 1.0 version. this commit updates the `rustix` dependency to the 1.0 release family.

for posterity, there is an overview of the changes between these two versions in the repository's changelog, [here](https://github.com/bytecodealliance/rustix/blob/main/CHANGES.md#api-changes).