### PR TITLE
Fix for trait derivation on wasm targets

### DIFF
--- a/procfs-core/src/process/namespaces.rs
+++ b/procfs-core/src/process/namespaces.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Information about a namespace
 #[derive(Debug, Clone, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(all(feature = "serde1", not(target_family = "wasm")), derive(Serialize, Deserialize))]
 pub struct Namespace {
     /// Namespace type
     pub ns_type: OsString,
@@ -28,5 +28,5 @@ impl PartialEq for Namespace {
 
 /// All namespaces of a process.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+#[cfg_attr(all(feature = "serde1", not(target_family = "wasm")), derive(Serialize, Deserialize))]
 pub struct Namespaces(pub HashMap<OsString, Namespace>);


### PR DESCRIPTION
The Namespaces struct uses OsStr, which is only available on Windows and Unix systems, leaving wasm targets unable to use the serde1 feature to deserialize other struct data. This change skips derivation of Serialize and Deserialize when targeting wasm as the build environment.