### PR TITLE
Add track_caller to check_unwrap test helper function

### DIFF
--- a/procfs/src/process/tests.rs
+++ b/procfs/src/process/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use rustix::process::Resource;
 use std::convert::TryInto;
 
+#[track_caller]
 fn check_unwrap<T>(prc: &Process, val: ProcResult<T>) -> Option<T> {
     match val {
         Ok(t) => Some(t),


### PR DESCRIPTION
Improves debugging experience by showing the actual test location when panics occur in check_unwrap, rather than the helper function location.