### PR TITLE
Add public constructor for CpuTime

### DIFF
--- a/procfs-core/src/lib.rs
+++ b/procfs-core/src/lib.rs
@@ -799,6 +799,34 @@ pub struct CpuTime {
 }
 
 impl CpuTime {
+    pub fn from_values(
+        user: u64,
+        nice: u64,
+        system: u64,
+        idle: u64,
+        iowait: Option<u64>,
+        irq: Option<u64>,
+        softirq: Option<u64>,
+        steal: Option<u64>,
+        guest: Option<u64>,
+        guest_nice: Option<u64>,
+        tps: u64,
+    ) -> CpuTime {
+        CpuTime {
+            user,
+            nice,
+            system,
+            idle,
+            iowait,
+            irq,
+            softirq,
+            steal,
+            guest,
+            guest_nice,
+            tps,
+        }
+    }
+
     fn from_str(s: &str, ticks_per_second: u64) -> ProcResult<CpuTime> {
         let mut s = s.split_whitespace();
 
@@ -819,19 +847,9 @@ impl CpuTime {
         let guest = s.next().map(|s| Ok(from_str!(u64, s))).transpose()?;
         let guest_nice = s.next().map(|s| Ok(from_str!(u64, s))).transpose()?;
 
-        Ok(CpuTime {
-            user,
-            nice,
-            system,
-            idle,
-            iowait,
-            irq,
-            softirq,
-            steal,
-            guest,
-            guest_nice,
-            tps,
-        })
+        Ok(CpuTime::from_values(
+            user, nice, system, idle, iowait, irq, softirq, steal, guest, guest_nice, tps,
+        ))
     }
 
     /// Milliseconds spent in user mode


### PR DESCRIPTION
To write tests for applications, that use CpuTime, it is very useful to mock CpuTime values to see how tested applications behave, depending on CPU load.

Because CpuTime have a private field tps and private from_str constructor function, the only way to mock it currently is to create a temporary file and actually write cpu time-like strings into a file and later read this file.

This makes using mocking libraries like mockall hard or impossible and complicates testing code that now have a state to cleanup (e.g. temporary file with mock data).

Adding a public constructor will help simplify it.

 