### PR TITLE
fix possible panic in test mode

### DIFF
--- a/procfs-core/src/meminfo.rs
+++ b/procfs-core/src/meminfo.rs
@@ -3,12 +3,12 @@ use super::{expect, from_str, ProcResult};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io};
 
-fn convert_to_kibibytes(num: u64, unit: &str) -> ProcResult<u64> {
+fn convert_to_bytes(num: u64, unit: &str) -> ProcResult<u64> {
     match unit {
         "B" => Ok(num),
-        "KiB" | "kiB" | "kB" | "KB" => Ok(num * 1024),
-        "MiB" | "miB" | "MB" | "mB" => Ok(num * 1024 * 1024),
-        "GiB" | "giB" | "GB" | "gB" => Ok(num * 1024 * 1024 * 1024),
+        "KiB" | "kiB" | "kB" | "KB" => Ok(num.saturating_mul(1024)),
+        "MiB" | "miB" | "MB" | "mB" => Ok(num.saturating_mul(1024 * 1024)),
+        "GiB" | "giB" | "GB" | "gB" => Ok(num.saturating_mul(1024 * 1024 * 1024)),
         unknown => Err(build_internal_error!(format!("Unknown unit type {}", unknown))),
     }
 }
@@ -321,7 +321,7 @@ impl super::FromBufRead for Meminfo {
             let value = from_str!(u64, value);
 
             let value = if let Some(unit) = unit {
-                convert_to_kibibytes(value, unit)?
+                convert_to_bytes(value, unit)?
             } else {
                 value
             };


### PR DESCRIPTION
It's possible some values in /proc/meminfo would be abnormally big which would overflow the multiply calculation.

Didn't find related link on Internet but my Ubuntu 24.04 once showed incorrect SwapFree size which caused panic in procfs.

```
MemTotal:       32405976 kB
MemFree:         2062608 kB
MemAvailable:    5264828 kB
Buffers:           78156 kB
Cached:          6070016 kB
SwapCached:            0 kB
Active:          8976496 kB
Inactive:       17864952 kB
Active(anon):    8207228 kB
Inactive(anon): 15150596 kB
Active(file):     769268 kB
Inactive(file):  2714356 kB
Unevictable:     1696048 kB
Mlocked:             112 kB
SwapTotal:      67108860 kB
SwapFree:       18446744073708600176 kB
...
```