### PR TITLE
Add Process:gid() to get the process group id.

### DIFF
--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -291,6 +291,11 @@ impl Process {
         }
     }
 
+    /// What group owns this process?
+    pub fn gid(&self) -> ProcResult<u32> {
+        Ok(self.metadata()?.st_gid)
+    }
+
     /// What user owns this process?
     pub fn uid(&self) -> ProcResult<u32> {
         Ok(self.metadata()?.st_uid)


### PR DESCRIPTION
Like Process:uid() but for the group id.