### PR TITLE
Fix a bunch of spelling mistakes

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -51,7 +51,7 @@ Under the following license:
 
 Copyright 2003 Binh Nguyen
 
-Under the GPL Free Documenation License. See: http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/ln14.html
+Under the GPL Free Documentation License. See: http://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/ln14.html
 
 
 ==================================

--- a/procfs-core/src/crypto.rs
+++ b/procfs-core/src/crypto.rs
@@ -122,9 +122,9 @@ pub enum Type {
     Skcipher(Skcipher),
     /// Single Block Cipher
     Cipher(Cipher),
-    /// Syncronous Hash
+    /// Synchronous Hash
     Shash(Shash),
-    /// Asyncronous Hash
+    /// Asynchronous Hash
     Ahash(Ahash),
     /// Authenticated Encryption with Associated Data
     Aead(Aead),

--- a/procfs-core/src/devices.rs
+++ b/procfs-core/src/devices.rs
@@ -16,7 +16,7 @@ pub struct Devices {
     pub block_devices: Vec<BlockDeviceEntry>,
 }
 
-/// A charcter device entry under `/proc/devices`
+/// A character device entry under `/proc/devices`
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct CharDeviceEntry {

--- a/procfs-core/src/lib.rs
+++ b/procfs-core/src/lib.rs
@@ -267,7 +267,7 @@ pub trait SystemInfoInterface {
 /// Auxiliary system information.
 pub type SystemInfo = dyn SystemInfoInterface;
 
-/// A convenience stuct implementing [SystemInfoInterface] with explicitly-specified values.
+/// A convenience struct implementing [SystemInfoInterface] with explicitly-specified values.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ExplicitSystemInfo {

--- a/procfs-core/src/meminfo.rs
+++ b/procfs-core/src/meminfo.rs
@@ -155,7 +155,7 @@ pub struct Meminfo {
     ///
     /// (since Linux 2.6.18)
     pub page_tables: Option<u64>,
-    /// Amount of memory allocated for seconary page tables. This currently includes KVM mmu
+    /// Amount of memory allocated for secondary page tables. This currently includes KVM mmu
     /// allocations on x86 and arm64.
     ///
     /// (since Linux 6.1)
@@ -273,7 +273,7 @@ pub struct Meminfo {
     /// needs documentation
     pub hugetlb: Option<u64>,
 
-    /// Memory allocated to the per-cpu alloctor used to back per-cpu allocations.
+    /// Memory allocated to the per-cpu allocator used to back per-cpu allocations.
     ///
     /// This stat excludes the cost of metadata.
     pub per_cpu: Option<u64>,
@@ -285,7 +285,7 @@ pub struct Meminfo {
 
     /// Undocumented field
     ///
-    /// (CONFIG_TRANSPARENT_HUGEPAGE is requried.  Since Linux 5.4)
+    /// (CONFIG_TRANSPARENT_HUGEPAGE is required.  Since Linux 5.4)
     pub file_pmd_mapped: Option<u64>,
 
     /// Undocumented field

--- a/procfs-core/src/pressure.rs
+++ b/procfs-core/src/pressure.rs
@@ -1,4 +1,4 @@
-//! Pressure stall information retreived from `/proc/pressure/cpu`,
+//! Pressure stall information retrieved from `/proc/pressure/cpu`,
 //! `/proc/pressure/memory` and `/proc/pressure/io`
 //! may not be available on kernels older than 4.20.0
 //! For reference: <https://lwn.net/Articles/759781/>

--- a/procfs-core/src/process/mount.rs
+++ b/procfs-core/src/process/mount.rs
@@ -542,7 +542,7 @@ pub struct NFSOperationStat {
     pub cum_queue_time: Duration,
     /// How long it took to get a response back.
     pub cum_resp_time: Duration,
-    /// How long all requests have taken from beeing queued to the point they where completely
+    /// How long all requests have taken from being queued to the point they where completely
     /// handled.
     pub cum_total_req_time: Duration,
 }

--- a/procfs/examples/README.md
+++ b/procfs/examples/README.md
@@ -4,7 +4,7 @@ These examples can be run by running `cargo run --example example_name`
 
 ## dump.rs
 
-Prints out details about the current process (the dumper itself), or a process specifed by PID
+Prints out details about the current process (the dumper itself), or a process specified by PID
 
 ## interface_stats.rs
 
@@ -102,7 +102,7 @@ and disks used for ZFS will not be shown either).
 
 ## lslocks.rs
 
-Shows current file locks in a format that is similiar to the `lslocks` utility.
+Shows current file locks in a format that is similar to the `lslocks` utility.
 
 ## mountinfo.rs
 
@@ -181,7 +181,6 @@ Lots of references to this locations: addr=0x81ba3000, pfn=531363, refs=128
 Found RAM here: 0x100000000-0x11fffffff
 Lots of references to this locations: addr=0x1b575000, pfn=111989, refs=134
 ```
-
 
 ## Crypto
 

--- a/procfs/examples/kpagecount.rs
+++ b/procfs/examples/kpagecount.rs
@@ -34,7 +34,7 @@ fn main() {
         println!("Found RAM here: 0x{:x}-0x{:x}", map.address.0, map.address.1);
 
         // Physical memory is divided into pages of `page_size` bytes (usually 4kiB)
-        // Each page is referenced by its Page Fram Number (PFN)
+        // Each page is referenced by its Page Frame Number (PFN)
         let (start_pfn, end_pfn) = map.get_range().get();
 
         let page_references = kpagecount

--- a/procfs/examples/netstat.rs
+++ b/procfs/examples/netstat.rs
@@ -43,7 +43,7 @@ fn main() {
                 local_address, remote_addr, state, entry.inode, stat.pid, stat.comm
             );
         } else {
-            // We might not always be able to find the process assocated with this socket
+            // We might not always be able to find the process associated with this socket
             println!(
                 "{:<26} {:<26} {:<15} {:<12} -",
                 local_address, remote_addr, state, entry.inode

--- a/procfs/src/crypto.rs
+++ b/procfs/src/crypto.rs
@@ -20,7 +20,7 @@ mod tests {
     #[test]
     fn read_crypto() {
         let table = crypto();
-        let table = table.expect("CrytoTable should have been read");
+        let table = table.expect("CryptoTable should have been read");
         assert!(!table.crypto_blocks.is_empty(), "Crypto table was empty");
     }
 }

--- a/procfs/src/lib.rs
+++ b/procfs/src/lib.rs
@@ -22,7 +22,7 @@
 //! sometimes the style of writing is not very "rusty", or may do things like reference related files
 //! (instead of referencing related structs).  Contributions to improve this are welcome.
 //!
-//! # Panicing
+//! # Panicking
 //!
 //! While previous versions of the library could panic, this current version aims to be panic-free
 //! in a many situations as possible.  Whenever the procfs crate encounters a bug in its own
@@ -859,7 +859,7 @@ mod tests {
         {
             assert!(meminfo.anon_hugepages.is_some());
         } else {
-            // SOme distributions may backport this option into older kernels
+            // Some distributions may backport this option into older kernels
             // assert!(meminfo.anon_hugepages.is_none());
         }
 

--- a/procfs/src/process/mod.rs
+++ b/procfs/src/process/mod.rs
@@ -438,7 +438,7 @@ impl Process {
     /// let stats = Process::myself().unwrap().mountstats().unwrap();
     ///
     /// for mount in stats {
-    ///     println!("{} mounted on {} wth type {}",
+    ///     println!("{} mounted on {} with type {}",
     ///         mount.device.unwrap_or("??".to_owned()),
     ///         mount.mount_point.display(),
     ///         mount.fs

--- a/procfs/src/process/task.rs
+++ b/procfs/src/process/task.rs
@@ -85,7 +85,7 @@ impl Task {
     /// Thread children from `/proc/<pid>/task/<tid>/children`
     ///
     /// WARNING:
-    /// This interface is not reliable unless all the child processes are stoppped or frozen.
+    /// This interface is not reliable unless all the child processes are stopped or frozen.
     /// If a child task exits while the file is being read, non-exiting children may be omitted.
     /// See the procfs(5) man page for more information.
     ///

--- a/procfs/src/process/tests.rs
+++ b/procfs/src/process/tests.rs
@@ -199,7 +199,7 @@ fn test_smaps() {
     let smaps = match me.smaps() {
         Ok(x) => x,
         Err(ProcError::NotFound(_)) => {
-            // ignored because not all kernerls have smaps
+            // ignored because not all kernels have smaps
             return;
         }
         Err(e) => panic!("{}", e),
@@ -213,7 +213,7 @@ fn test_smaps_rollup() {
     let smaps_rollup = match me.smaps_rollup() {
         Ok(x) => x,
         Err(ProcError::NotFound(_)) => {
-            // ignored because not all kernerls have smaps_rollup
+            // ignored because not all kernels have smaps_rollup
             return;
         }
         Err(e) => panic!("{}", e),

--- a/procfs/src/sys/fs/epoll.rs
+++ b/procfs/src/sys/fs/epoll.rs
@@ -2,7 +2,7 @@ use crate::{read_value, write_value, ProcResult};
 
 /// Get the limit on the total number of file descriptors that a user can register across all epoll instances.
 ///
-/// The limit is per real user ID.  Each registered file descriptor costs roughtly 90 bytes on a 32-bit kernel,
+/// The limit is per real user ID.  Each registered file descriptor costs roughly 90 bytes on a 32-bit kernel,
 /// and roughly 160 bytes on a 64-bit kernel.  Currently, the default value for `max_user_watches` is 1/25 (4%)
 /// of the available low memory, divided by the registration cost in bytes.
 ///


### PR DESCRIPTION
This is more or less a drive by fix. 
I was reading the documentation and noticed one mistake. Afterward I turned to the [typos](https://github.com/crate-ci/typos) spell checker for finding the other mistakes ;)

The change in the bit flag might be breaking if anyone is using this directly. I can also drop the commit if necessary.