### PR TITLE
Add IRQ pressure metrics

### DIFF
--- a/procfs-core/src/pressure.rs
+++ b/procfs-core/src/pressure.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// Pressure stall information for either CPU, memory, or IO.
+/// Pressure stall information for either CPU, memory, IRQ or IO.
 ///
 /// See also: <https://www.kernel.org/doc/Documentation/accounting/psi.txt>
 #[derive(Debug, Clone)]
@@ -89,6 +89,26 @@ impl super::FromBufRead for IoPressure {
     fn from_buf_read<R: std::io::BufRead>(r: R) -> ProcResult<Self> {
         let (some, full) = get_pressure(r)?;
         Ok(IoPressure { some, full })
+    }
+}
+
+/// IRQ pressure information, only available if the kernel was compiled with CONFIG_IRQ_TIME_ACCOUNTING=y
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+pub struct IrqPressure {
+    /// This record indicates this share of time in which all non-idle tasks are stalled
+    /// simultaneously.
+    pub full: PressureRecord,
+}
+
+impl super::FromBufRead for IrqPressure {
+    fn from_buf_read<R: std::io::BufRead>(r: R) -> ProcResult<Self> {
+        let mut full = String::new();
+        let mut reader = r;
+        reader.read_line(&mut full)?;
+        Ok(IrqPressure {
+            full: parse_pressure_record(&full)?,
+        })
     }
 }
 

--- a/procfs/examples/pressure.rs
+++ b/procfs/examples/pressure.rs
@@ -1,4 +1,4 @@
-use procfs::{prelude::*, CpuPressure, IoPressure, MemoryPressure, PressureRecord};
+use procfs::{prelude::*, CpuPressure, IoPressure, IrqPressure, MemoryPressure, PressureRecord};
 
 /// A basic example of /proc/pressure/ usage.
 fn main() {
@@ -13,11 +13,17 @@ fn main() {
         println!("CPU Pressure:");
         print_pressure(pressure.some, 20);
     }
+
     if let Ok(pressure) = IoPressure::current() {
         println!("IO Pressure:");
         println!("{:>10}:", "Some");
         print_pressure(pressure.some, 20);
         println!("{:>10}:", "Full");
+        print_pressure(pressure.full, 20);
+    }
+
+    if let Ok(pressure) = IrqPressure::current() {
+        println!("IRQ Pressure:");
         print_pressure(pressure.full, 20);
     }
 }

--- a/procfs/src/lib.rs
+++ b/procfs/src/lib.rs
@@ -496,6 +496,10 @@ impl Current for IoPressure {
     const PATH: &'static str = "/proc/pressure/io";
 }
 
+impl Current for IrqPressure {
+    const PATH: &'static str = "/proc/pressure/irq";
+}
+
 impl Current for SharedMemorySegments {
     const PATH: &'static str = "/proc/sysvipc/shm";
 }


### PR DESCRIPTION
These metrics are only accounted for if the kernel was compiled with `CONFIG_IRQ_TIME_ACCOUNTING=y`.
Closes #351